### PR TITLE
Update to crate-docs-theme==0.30.0.dev5. Rename module slot to singular.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,4 @@
-from crate.theme.rtd.conf.cratedb_guides import *
+from crate.theme.rtd.conf.cratedb_guide import *
 
 # Disable version chooser.
 html_context.update({

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,1 @@
-crate-docs-theme==0.30.0.dev3
+crate-docs-theme==0.30.0.dev5


### PR DESCRIPTION
## About

Belongs to GH-11, but needs a new release of crate-docs-theme. cratedb-guide currently uses a pre-release `crate-docs-theme==0.30.0.dev3`, which includes this slot. GA releases don't, that's why the new thing is only semi-live.

## Depends on
Unless updating that upstream patch, this one will fail CI.

- https://github.com/crate/crate-docs-theme/pull/448

## Preview
https://cratedb-guide--12.org.readthedocs.build/
