### PR TITLE
Chore: Make link checker ignore links to Stack Overflow

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,9 +9,12 @@ html_context.update({
 
 # Configure link checker.
 linkcheck_ignore = [
-    # Forbidden by WordPress
-    "https://crate.io/wp-content/uploads/2018/11/copy_from_population_data.zip",
-    r'http://localhost:\d+/',
+    # Generic ignores.
+    r"http://localhost:\d+/",
+    # Forbidden by WordPress.
+    r"https://crate.io/wp-content/uploads/2018/11/copy_from_population_data.zip",
+    # Forbidden by Stack Overflow.
+    r"https://stackoverflow.com/.*",
 ]
 
 if "sphinx.ext.intersphinx" not in extensions:


### PR DESCRIPTION
It looks like Stackoverflow does not like to be requested from GitHub today. On the other hand, the link checker works well on my machine. It will probably need an adjustment on the "link ignore" settings, at least temporarily.

```
(admin/performance/selects: line   98) broken    https://stackoverflow.com/a/2705123 - 403 Client Error: Forbidden for url: https://stackoverflow.com/a/2705123
```
-- https://github.com/crate/cratedb-guide/actions/runs/7972899296/job/21765730000?pr=15#step:4:1004