### PR TITLE
Chore: Remove prose boilerplate "This section of the documentation"

### DIFF
--- a/docs/admin/clustering/index.rst
+++ b/docs/admin/clustering/index.rst
@@ -5,9 +5,7 @@ Clustering
 ==========
 
 One of the benefits of CrateDB is that you can scale out your cluster by
-adding more nodes.
-
-This section of the documentation shows you how to cluster and scale CrateDB.
+adding more nodes. This section of the documentation covers that topic.
 
 .. rubric:: Table of contents
 

--- a/docs/admin/index.rst
+++ b/docs/admin/index.rst
@@ -5,8 +5,7 @@
 Administration
 ##############
 
-This section of the documentation covers CrateDB database
-administration practices.
+CrateDB database administration practices.
 
 .. toctree::
     :maxdepth: 1

--- a/docs/admin/performance/index.rst
+++ b/docs/admin/performance/index.rst
@@ -4,8 +4,7 @@
 Performance
 ===========
 
-This section of the documentation shows you how tune your setup and get the
-best performance from CrateDB.
+Tune your setup and get the best performance from CrateDB.
 
 .. rubric:: Table of contents
 

--- a/docs/domain/timeseries/index.rst
+++ b/docs/domain/timeseries/index.rst
@@ -4,8 +4,7 @@
 Time Series Data
 ################
 
-This section of the documentation covers integrations of CrateDB with other
-tools, with respect to time-series use-cases.
+Integrations of CrateDB with other tools, with respect to time-series use-cases.
 
 
 .. .. rubric:: Basics

--- a/docs/install/debian-ubuntu.rst
+++ b/docs/install/debian-ubuntu.rst
@@ -8,9 +8,10 @@
 CrateDB on Debian, Ubuntu, and Derivates
 ########################################
 
-This section of the documentation outlines how to install CrateDB deb_ packages
-using the apt_ package manager.
+Install CrateDB deb_ packages using the apt_ package manager.
 
+This installation method is suitable for Debian systems and derivates
+like Ubuntu.
 
 Configure package repository
 ============================

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -7,6 +7,7 @@ Installation
 This section of the documentation covers the installation of CrateDB on different
 kinds of operating systems and environments, both suitable for on-premises and
 development sandbox operations.
+
 The first step to using any software package is getting it properly installed.
 Please read this section carefully.
 

--- a/docs/install/redhat.rst
+++ b/docs/install/redhat.rst
@@ -8,8 +8,7 @@
 CrateDB on Red Hat, SUSE, and Derivates
 #######################################
 
-This section of the documentation outlines how to install CrateDB RPM_ packages
-using the YUM_ package manager.
+Install CrateDB RPM_ packages using the YUM_ package manager.
 
 This installation method is suitable for RedHat Enterprise Linux (RHEL) and compatible
 systems like Fedora, CentOS, Rocky Linux, AlmaLinux, AWS Linux, Oracle Linux, or

--- a/docs/install/windows.rst
+++ b/docs/install/windows.rst
@@ -6,8 +6,7 @@
 Running CrateDB on Windows
 ##########################
 
-This section of the documentation outlines how to use the release archives to
-run CrateDB on Microsoft Windows.
+How to use the release archives to run CrateDB on Microsoft Windows.
 
 .. CAUTION::
 


### PR DESCRIPTION
## About
Starting each page with the venerable "This section of the documentation {covers,outlines,demonstrates}" is just too much boilerplate, no?

## Details
There are just four leftovers, which is acceptable.
