### PR TITLE
Style: Make tile gallery on "install" page responsive

### DIFF
--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -38,7 +38,7 @@ Please read this section carefully.
 .. the following sections explicitly
 
 
-.. grid:: 4
+.. grid:: 2 2 2 4
     :padding: 0
     :class-container: installation-grid
 


### PR DESCRIPTION
## Problem
The "install" page did not display well on smaller screens, like mobile phones.

## Solution
Use responsive features of [Bootstrap](https://en.wikipedia.org/wiki/Bootstrap_(front-end_framework)) per [sphinx{design}](https://sphinx-design.readthedocs.io/).

## Preview
Before: https://cratedb.com/docs/guide/install/index.html
After: https://cratedb-guide--32.org.readthedocs.build/install/index.html

![image](https://github.com/crate/cratedb-guide/assets/453543/b2558ea6-f3a7-4444-8bd6-9bb71e9cc78f) ![image](https://github.com/crate/cratedb-guide/assets/453543/b55be8ad-06be-497a-ab9a-e57a8dd7fdbd)

/cc @karynzv, @seut, @matriv, @hlcianfagna, @hammerhead, @proddata, @ckurze 