### PR TITLE
Administration/Upgrading: Add index page for "Upgrading" section

### DIFF
--- a/docs/admin/index.rst
+++ b/docs/admin/index.rst
@@ -27,11 +27,9 @@ clustering, sharding, partitioning, and performance tuning.
     performance/index
 
 
-Guidelines about upgrading CrateDB.
+Guidelines about upgrading CrateDB clusters.
 
 .. toctree::
     :maxdepth: 1
 
-    upgrade/planning
-    upgrade/rolling
-    upgrade/full
+    upgrade/index

--- a/docs/admin/upgrade/full.rst
+++ b/docs/admin/upgrade/full.rst
@@ -3,7 +3,7 @@
 .. _full_restart_upgrade:
 
 ====================
-Full restart upgrade
+Full Restart Upgrade
 ====================
 
 .. rubric:: Table of contents
@@ -32,7 +32,7 @@ done if you want to update CrateDB.
    To do a full restart upgrade with Docker, you must remove the CrateDB
    service and then recreate it.
 
-Upgrade process
+Upgrade Process
 ===============
 
 .. WARNING::

--- a/docs/admin/upgrade/index.md
+++ b/docs/admin/upgrade/index.md
@@ -1,0 +1,11 @@
+# Upgrading
+
+Guidelines about upgrading CrateDB clusters.
+
+```{toctree}
+:maxdepth: 2
+
+Guidelines <planning>
+rolling
+full
+```

--- a/docs/admin/upgrade/planning.rst
+++ b/docs/admin/upgrade/planning.rst
@@ -5,7 +5,7 @@
 
 
 ==========================
-General upgrade guidelines
+General Upgrade Guidelines
 ==========================
 
 .. rubric:: Table of contents
@@ -14,7 +14,7 @@ General upgrade guidelines
    :local:
 
 
-Upgrade planning
+Upgrade Planning
 ================
 Before kicking off an upgrade, there is a set of guidelines to ensure the best outcome. Below you may find the fundamental steps to prepare for an upgrade.
 

--- a/docs/admin/upgrade/rolling.rst
+++ b/docs/admin/upgrade/rolling.rst
@@ -2,7 +2,7 @@
 .. _rolling_upgrade:
 
 ===============
-Rolling upgrade
+Rolling Upgrade
 ===============
 
 .. rubric:: Table of contents


### PR DESCRIPTION
## About
Spend a little index page on the "Upgrading" section, in order to save vertical space within the primary navigation, and to improve guidance.

## Before / After
With screenshots.

![image](https://github.com/crate/cratedb-guide/assets/453543/7ba07523-6bc7-4845-be95-c51336678310) ![image](https://github.com/crate/cratedb-guide/assets/453543/a16fe07d-1c8b-496f-8451-16af95194c3c)

## Preview
- https://cratedb-guide--43.org.readthedocs.build/admin/upgrade/

/cc @surister, @karynzv, @marijaselakovic, @hammerhead, @proddata, @wierdvanderhaar, @msbt, @matkuliak 