### PR TITLE
Update to vanilla / most recent crate-docs-theme

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,4 @@
-crate-docs-theme==0.30.0.dev8
+crate-docs-theme
+
+# cache-buster-20240305
+# Remark: Used for PyPI download cache busting on GHA.


### PR DESCRIPTION
## About

Make cratedb-guide always use the most recent release of crate-docs-theme, detouring from using a pre-release version.

/cc @seut, @ckurze 