### PR TITLE
Sphinx settings: Configure that project is not using versioning or i18n

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,6 +3,9 @@ from crate.theme.rtd.conf.cratedb_guide import *
 # Fallback guards, when parent theme does not introduce them.
 if "html_theme_options" not in globals():
     html_theme_options = {}
+if "intersphinx_mapping" not in globals():
+    intersphinx_mapping = {}
+
 # Configure sitemap generation URLs.
 sitemap_url_scheme = "{link}"
 
@@ -28,12 +31,7 @@ linkcheck_ignore = [
     r"https://stackoverflow.com/.*",
 ]
 
-if "sphinx.ext.intersphinx" not in extensions:
-    extensions += ["sphinx.ext.intersphinx"]
-
-if "intersphinx_mapping" not in globals():
-    intersphinx_mapping = {}
-
+# Configure intersphinx.
 intersphinx_mapping.update({
     'matplotlib': ('https://matplotlib.org/stable/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,16 @@
 from crate.theme.rtd.conf.cratedb_guide import *
 
+# Fallback guards, when parent theme does not introduce them.
+if "html_theme_options" not in globals():
+    html_theme_options = {}
+# Configure sitemap generation URLs.
+sitemap_url_scheme = "{link}"
+
+# Configure rel="canonical" link URLs.
+html_theme_options.update({
+        "canonical_url_path": "%s/" % url_path,
+})
+
 # Disable version chooser.
 html_context.update({
     "display_version": False,

--- a/docs/install/configure.rst
+++ b/docs/install/configure.rst
@@ -15,7 +15,7 @@ When using the package-based setup flavor for :ref:`install-deb` or
 :ref:`install-rpm`, the main CrateDB configuration files are located within the
 ``/etc/crate`` directory.
 
-When using the :ref:`install-adhoc` setup, or the :ref:`Microsoft Windows <windows-install>`
+When using the :ref:`install-adhoc` setup, or the :ref:`Microsoft Windows <install-windows>`
 setup, the configuration files are located within the ``config/`` directory relative to the
 working directory.
 
@@ -31,7 +31,7 @@ environment variables.
     RPM packages of CrateDB versions up to `5.2.11`_, `5.3.8`_, `5.4.7`_
     and `5.5.2`_ are using the ``/etc/sysconfig/crate`` file instead.
 
-When using the :ref:`install-adhoc` setup, or the :ref:`Microsoft Windows <windows-install>`
+When using the :ref:`install-adhoc` setup, or the :ref:`Microsoft Windows <install-windows>`
 setup, the environment variables will be defined by ``bin/crate{.sh,.bat}`` relative to the
 working directory.
 

--- a/docs/install/debian-ubuntu.rst
+++ b/docs/install/debian-ubuntu.rst
@@ -1,5 +1,7 @@
 .. highlight:: bash
 
+.. _debian:
+.. _ubuntu:
 .. _install-deb:
 .. _install-debian:
 .. _install-ubuntu:

--- a/docs/install/redhat.rst
+++ b/docs/install/redhat.rst
@@ -1,5 +1,6 @@
 .. highlight:: bash
 
+.. _red-hat:
 .. _install-rpm:
 .. _install-redhat:
 .. _install-suse:


### PR DESCRIPTION
## Problem

The new documentation section raised many 404 errors on the link checker service, because Sphinx generated the wrong links, considering the project to be versioned, like the others, while it isn't. This patch aims to remedy them.

## Details
Screenshots about two occasions where the wrong links have been used.
### Sitemap
![image](https://github.com/crate/cratedb-guide/assets/453543/43ae3223-5f3c-490a-b673-bba6e9cdcb0e)

### rel="canonical" link URLs
![image](https://github.com/crate/cratedb-guide/assets/453543/05608801-0326-427d-89db-d982b67be35f)


## Preview
https://cratedb-guide--61.org.readthedocs.build/