### PR TITLE
Chore: Fix link to "Data Visualization" page

### DIFF
--- a/docs/domain/ml/tensorflow.rst
+++ b/docs/domain/ml/tensorflow.rst
@@ -547,7 +547,7 @@ distributed across different machines, contexts, and scenarios.
 .. _numpy: https://numpy.org/
 .. _pandas: https://pandas.pydata.org/
 .. _psycopg2: https://pypi.org/project/psycopg2/
-.. _pump_sensor_data: https://www.kaggle.com/nphantawee/pump-sensor-data
+.. _pump_sensor_data: https://www.kaggle.com/code/shawkyelgendy/pump-sensor-data-timeseriesanalysis
 .. _Python: https://www.python.org/
 .. _ReLU: https://en.wikipedia.org/wiki/Rectifier_(neural_networks)
 .. _sklearn: https://scikit-learn.org/stable/

--- a/docs/index.md
+++ b/docs/index.md
@@ -196,7 +196,7 @@ frameworks.
 
 
 :::{grid-item-card} Data Visualization
-:link: analysis
+:link: visualization
 :link-type: ref
 :link-alt: Data visualization with CrateDB
 :padding: 3


### PR DESCRIPTION
## About

Fixes a wrongly assigned link on the main intro page. Thanks for reporting, @hlcianfagna.