### PR TITLE
Fix references to outdated projects

### DIFF
--- a/docs/build.json
+++ b/docs/build.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
   "label": "docs build",
-  "message": "2.1.1"
+  "message": "2.1.2"
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,6 +29,8 @@ linkcheck_ignore = [
     r"https://cratedb.com/wp-content/uploads/2018/11/copy_from_population_data.zip",
     # Forbidden by Stack Overflow.
     r"https://stackoverflow.com/.*",
+    # Expired certificate.
+    r"https://tldp.org/LDP/Linux-Filesystem-Hierarchy/html/index.html",
 ]
 
 # Configure intersphinx.

--- a/docs/domain/timeseries/generate/cli.rst
+++ b/docs/domain/timeseries/generate/cli.rst
@@ -290,7 +290,7 @@ will open up a map view showing the current position of the ISS:
 .. _ground point: https://en.wikipedia.org/wiki/Ground_track
 .. _International Space Station: https://www.nasa.gov/mission_pages/station/main/index.html
 .. _jq: https://stedolan.github.io/jq/
-.. _let us know: https://github.com/crate/crate-tutorials/issues/new
+.. _let us know: https://github.com/crate/cratedb-guide/issues/new
 .. _open notify: http://open-notify.org/
 .. _pip: https://pypi.org/project/pip/
 .. _pipe: https://www.geeksforgeeks.org/piping-in-unix-or-linux/

--- a/docs/install/_post-install.rst
+++ b/docs/install/_post-install.rst
@@ -13,11 +13,11 @@ Admin UI can be visited at::
 Also, let us outline those information entrypoints as suggestions to explore next:
 
 * Read more details about the :ref:`crate-reference:config`.
-* The background about :ref:`crate-howtos:bootstrap-checks`.
+* The background about :ref:`bootstrap-checks`.
 * Multi-node configuration within the section about :ref:`crate-howtos:clustering`
-  and :ref:`crate-howtos:going-into-production`.
+  and :ref:`going-into-production`.
 * When operating a CrateDB cluster in production, please also take
-  :ref:`performance tuning <crate-howtos:performance>` into consideration.
+  :ref:`performance tuning <performance>` into consideration.
 
 .. NOTE::
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
- Fixed outdated references
- Bumped `build.json` version to 2.1.2


## Checklist

 - [x] Link to issue this PR refers to (if applicable): https://github.com/crate/tech-writing/issues/416
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
