### PR TITLE
Installation: Update section about installing RPM packages

### DIFF
--- a/docs/install/redhat.rst
+++ b/docs/install/redhat.rst
@@ -9,7 +9,7 @@
 CrateDB on Red Hat, SUSE, and Derivates
 #######################################
 
-Install CrateDB RPM_ packages using the YUM_ package manager.
+Install CrateDB RPM_ packages using the DNF_, YUM_, or ZYpp_ package managers.
 
 This installation method is suitable for RedHat Enterprise Linux (RHEL) and compatible
 systems like Fedora, CentOS, Rocky Linux, AlmaLinux, AWS Linux, Oracle Linux, or
@@ -19,30 +19,37 @@ Scientific Linux. Installation also works on openSUSE and SUSE Linux Enterprise 
 Configure package repository
 ============================
 
-You will need to configure your system to register with and trust packages
-from the CrateDB package repository::
+To register with the CrateDB package repository, create a file called ``cratedb.repo``
+in the ``/etc/yum.repos.d/`` directory for RedHat based distributions, or in the
+``/etc/zypp/repos.d/`` directory for OpenSuSE based distributions, containing::
 
-    # Install prerequisites.
-    yum install sudo
+    [cratedb-ce-stable]
+    name=CrateDB RPM package repository - $basearch - Stable
+    baseurl=https://cdn.crate.io/downloads/yum/7/$basearch
+    enabled=0
+    gpgcheck=1
+    gpgkey=https://cdn.crate.io/downloads/yum/RPM-GPG-KEY-crate
+    autorefresh=1
+    type=rpm-md
 
-    # Import the public GPG key for verifying the package signatures.
-    sudo rpm --import https://cdn.crate.io/downloads/yum/RPM-GPG-KEY-crate
-
-    # Register with the CrateDB package repository.
-    sudo rpm -Uvh https://cdn.crate.io/downloads/yum/7/x86_64/crate-release-7.0-1.x86_64.rpm
-
-The command above will install the ``/etc/yum.repos.d/crate.repo`` package
-repository configuration file.
+    [cratedb-ce-testing]
+    name=CrateDB RPM package repository - $basearch - Testing
+    baseurl=https://cdn.crate.io/downloads/yum/testing/7/$basearch
+    enabled=0
+    gpgcheck=1
+    gpgkey=https://cdn.crate.io/downloads/yum/RPM-GPG-KEY-crate
+    autorefresh=1
+    type=rpm-md
 
 .. NOTE::
 
-    CrateDB provides both *stable release* and *testing release* channels. You
-    can read more about the `release workflow`_.
+    The configured repository is disabled by default. This eliminates the
+    possibility of accidentally upgrading CrateDB when upgrading the rest
+    of the system. Each install or upgrade command must explicitly enable
+    the repository as indicated in the sample installation command below.
 
-    By default, yum_ (Red Hat's package manager) will use the stable
-    repository. This is because the testing repository is disabled.
-    If you would like to enable the testing repository, edit the ``crate.repo``
-    file and set ``enabled=1`` within the ``[crate-testing]`` section.
+CrateDB provides both *stable release* and *testing release* channels. You
+can read more about the `release workflow`_.
 
 
 Install CrateDB
@@ -50,7 +57,13 @@ Install CrateDB
 
 With everything set up, you can install CrateDB::
 
-    sudo yum install crate
+    sudo dnf install --enablerepo=cratedb-ce-stable crate
+
+.. TIP::
+
+    On older Red Hat and CentOS installations, please use the ``yum`` command
+    instead of ``dnf``. On SUSE based installations, please use the ``zypper``
+    command.
 
 
 Configure CrateDB
@@ -60,10 +73,25 @@ Please visit the :ref:`install-configure` documentation section to learn
 about the location and meaning of CrateDB's configuration files.
 
 
+Trust signing key
+=================
+
+In order to trust the package signing key upfront, before being prompted
+to do it on the first installation of CrateDB, you can also import it
+into your repository keyring, like that::
+
+    # Install prerequisites.
+    yum install sudo
+
+    # Import the public GPG key for verifying the package signatures.
+    sudo rpm --import https://cdn.crate.io/downloads/yum/RPM-GPG-KEY-crate
+
 
 .. include:: _control-linux.rst
 .. include:: _post-install.rst
 
+.. _DNF: https://en.wikipedia.org/wiki/DNF_(software)
 .. _release workflow: https://github.com/crate/crate/blob/master/devs/docs/release.rst
 .. _RPM: https://en.wikipedia.org/wiki/RPM_Package_Manager
 .. _YUM: https://en.wikipedia.org/wiki/Yum_(software)
+.. _ZYpp: https://en.wikipedia.org/wiki/ZYpp


### PR DESCRIPTION
## About

Registering with the RPM package repository using the `crate-release-7.0-1.x86_64.rpm` packages and friends is being deprecated. It is advised to configure the RPM repository manually instead.

## Preview

https://cratedb-guide--69.org.readthedocs.build/install/redhat.html

## Caveat

I've only edited the documentation, **without doing any kind of validation yet.** Maybe you can spare a few minutes? Thanks for your support!

/cc @hlcianfagna, @WalBeh, @BaurzhanSakhariev, @matriv 