### PR TITLE
Home: Add new top-level documentation landing page, indexing the main entrypoints

### DIFF
--- a/docs/home/index.md
+++ b/docs/home/index.md
@@ -12,13 +12,15 @@ orphan: true
 
 
 
-# CrateDB Documentation
+# Welcome to CrateDB!
 
-Documentation overview for CrateDB and CrateDB Cloud.
-<br>
-Reference manuals, tutorials, example code, and more.
+CrateDB is designed to handle your demanding analytics and search workloads with
+ease. Here you'll find comprehensive resources including reference manuals,
+tutorials, example code, and more.
 
-::::{grid} 1 1 2 2
+Happy learning and building with CrateDB!
+
+::::{grid} 1
 :margin: 1
 :padding: 2
 
@@ -29,36 +31,37 @@ Reference manuals, tutorials, example code, and more.
 :padding: 2
 :class-title: sd-fs-5
 
-CrateDB Cloud is a fully managed, terabyte-scale, and cost-effective analytics
-database that lets you run analytics over vast amounts of data in near real time,
-even with complex queries.
+Discover the fully managed, scalable SQL database designed for
+real-time search and analytics. It supports fast analytics applications with
+real-time indexing of time-series, JSON, vector, text, and geo data. Perform
+near real-time analytics on vast data sets with complex queries and streamline
+data management across multiple cloud providers.
 
-CrateDB Cloud is an SQL database service for enterprise data warehouse workloads,
-that works across clouds and scales with your data.
-:::
-
-:::{grid-item-card} {material-outlined}`auto_stories;1.7em` Database Manual
-:link: cloud-docs-index
-:link-type: ref
-:link-alt: CrateDB Cloud
-:padding: 2
-:class-title: sd-fs-5
-
-CrateDB is a distributed and scalable SQL database for storing and
-analyzing massive amounts of data in near real-time, even with complex queries.
-It is PostgreSQL-compatible, and based on Lucene. 
-
-CrateDB is an open source multi-model database for time series, documents
-and vectors, combining the simplicity of SQL with the scalability of a
-distributed architecture.
+[Get started now!](https://cratedb.com/docs/cloud/tutorials/quick-start.html)
 :::
 
 ::::
 
 
-::::{grid} 1
+::::{grid} 1 1 2 2
 :margin: 1
 :padding: 2
+
+:::{grid-item-card} {material-outlined}`auto_stories;1.7em` Reference Manual
+:link: https://cratedb.com/docs/reference/
+:link-alt: CrateDB Reference Manual
+:padding: 2
+:class-title: sd-fs-5
+
+Want to dive deep into CrateDB? Explore the comprehensive reference manual.
+
+At the core of CrateDB Cloud sits CrateDB, the open-source, distributed, and
+scalable SQL database system designed for storing and analyzing massive amounts
+of data in real-time, even with complex queries.
+
+Based on Lucene, CrateDB supports time series, documents, and vectors, combining
+the simplicity of SQL with the scalability of a distributed architecture
+:::
 
 :::{grid-item-card} {material-outlined}`link;1.7em` Client Libraries
 :link: https://cratedb.com/docs/crate/clients-tools/en/latest/connect/
@@ -73,7 +76,6 @@ CrateDB supports both the [HTTP protocol] and the [PostgreSQL wire protocol],
 which ensures that many clients that work with PostgreSQL, will also work with
 CrateDB. Through corresponding drivers, CrateDB is compatible with [ODBC],
 [JDBC], and other database API specifications.
-
 :::
 
 ::::
@@ -157,7 +159,7 @@ and integrations with 3rd-party applications.
 
 {material-outlined}`category;3.5em`
 +++
-Discover integrations and solutions from the open source community and CrateDB partners.
+Discover integrations and solutions from the open-source community and CrateDB partners.
 :::
 
 

--- a/docs/home/index.md
+++ b/docs/home/index.md
@@ -59,8 +59,9 @@ At the core of CrateDB Cloud sits CrateDB, the open-source, distributed, and
 scalable SQL database system designed for storing and analyzing massive amounts
 of data in real-time, even with complex queries.
 
-Based on Lucene, CrateDB supports time series, documents, and vectors, combining
-the simplicity of SQL with the scalability of a distributed architecture
+Based on Lucene and inherited from Elasticsearch/OpenSearch, CrateDB supports
+time series, documents, and vectors, combining the simplicity of SQL with the
+scalability of a distributed architecture.
 :::
 
 :::{grid-item-card} {material-outlined}`link;1.7em` Client Libraries
@@ -86,25 +87,76 @@ CrateDB. Through corresponding drivers, CrateDB is compatible with [ODBC],
 
 :::{rubric} Introduction
 :::
-Learn about the fundamentals of CrateDB and its utility applications.
+Learn about the fundamentals of CrateDB, guided and self-guided.
 
-::::{grid} 2 3 3 3
+::::{grid} 2 2 4 4
 :padding: 0
 
-:::{grid-item-card} Getting Started
+:::{grid-item-card}
 :link: https://cratedb.com/docs/guide/getting-started.html
 :link-alt: Getting started with CrateDB
 :padding: 3
-:class-card: sd-pt-3
-:class-title: sd-fs-5
-:class-body: sd-text-center
+:class-header: sd-text-center sd-fs-5 sd-align-minor-center sd-font-weight-bold sd-text-capitalize
+:class-body: sd-text-center sd-fs-5
 :class-footer: text-smaller
-
+Getting Started
+^^^
 {material-outlined}`lightbulb;3.5em`
 +++
 Learn how to interact with the database for the first time.
 :::
 
+:::{grid-item-card}
+:link: https://cratedb.com/docs/guide/
+:link-alt: The CrateDB Guide
+:padding: 3
+:class-header: sd-text-center sd-fs-5 sd-align-minor-center sd-font-weight-bold sd-text-capitalize
+:class-body: sd-text-center sd-fs-5
+:class-footer: text-smaller
+The CrateDB Guide
+^^^
+{material-outlined}`hiking;3.5em`
++++
+Guides and tutorials about how to use CrateDB in practice.
+:::
+
+:::{grid-item-card}
+:link: https://learn.cratedb.com/
+:link-alt: The CrateDB Academy
+:padding: 3
+:class-header: sd-text-center sd-fs-5 sd-align-minor-center sd-font-weight-bold sd-text-capitalize
+:class-body: sd-text-center sd-fs-5
+:class-footer: text-smaller
+Academy Courses
+^^^
+{material-outlined}`school;3.5em`
++++
+A learning hub dedicated to data enthusiasts.
+:::
+
+:::{grid-item-card}
+:link: https://community.cratedb.com/
+:link-alt: The CrateDB Community Portal
+:padding: 3
+:class-header: sd-text-center sd-fs-5 sd-align-minor-center sd-font-weight-bold sd-text-capitalize
+:class-body: sd-text-center sd-fs-5
+:class-footer: text-smaller
+Community Portal
+^^^
+{material-outlined}`groups;3.5em`
++++
+A hangout place for members of the CrateDB community.
+:::
+
+::::
+
+
+:::{rubric} Database Clients and Tools
+:::
+Learn about the fundamental tools and utility programs that support working directly with CrateDB.
+
+::::{grid} 2 3 3 3
+:padding: 0
 
 :::{grid-item-card} Admin UI
 :link: https://cratedb.com/docs/crate/admin-ui/
@@ -114,12 +166,10 @@ Learn how to interact with the database for the first time.
 :class-title: sd-fs-5
 :class-body: sd-text-center
 :class-footer: text-smaller
-
 {material-outlined}`admin_panel_settings;3.5em`
 +++
 Learn about CrateDB's included web administration interface.
 :::
-
 
 :::{grid-item-card} Crash CLI
 :link: https://cratedb.com/docs/crate/crash/
@@ -129,7 +179,6 @@ Learn about CrateDB's included web administration interface.
 :class-title: sd-fs-5
 :class-body: sd-text-center
 :class-footer: text-smaller
-
 {material-outlined}`terminal;3.5em`
 +++
 A command-line interface (CLI) tool for working with CrateDB.
@@ -142,7 +191,7 @@ A command-line interface (CLI) tool for working with CrateDB.
 :::
 
 Learn about database client libraries, drivers, adapters, connectors,
-and integrations with 3rd-party applications.
+and integrations with 3rd-party applications and frameworks.
 
 ::::{grid} 2 3 3 3
 :padding: 0
@@ -156,7 +205,6 @@ and integrations with 3rd-party applications.
 :class-title: sd-fs-5
 :class-body: sd-text-center
 :class-footer: text-smaller
-
 {material-outlined}`category;3.5em`
 +++
 Discover integrations and solutions from the open-source community and CrateDB partners.
@@ -172,8 +220,7 @@ Discover integrations and solutions from the open-source community and CrateDB p
 :class-title: sd-fs-5
 :class-body: sd-text-center
 :class-footer: text-smaller
-
-{material-outlined}`school;3.5em`
+{material-outlined}`integration_instructions;3.5em`
 +++
 Learn about the variety of options to connect and integrate with 3rd-party applications.
 :::
@@ -187,7 +234,6 @@ Learn about the variety of options to connect and integrate with 3rd-party appli
 :class-title: sd-fs-5
 :class-body: sd-text-center
 :class-footer: text-smaller
-
 {material-outlined}`local_library;3.5em`
 +++
 Integration-focused tutorials to help you use CrateDB together with other tools and libraries.
@@ -212,7 +258,6 @@ Learn how to use CrateDB by digesting concise examples.
 :class-title: sd-fs-5
 :class-body: sd-text-center
 :class-footer: text-smaller
-
 {material-outlined}`play_circle;3.5em`
 +++
 A collection of clear and concise examples how to work with CrateDB.
@@ -226,7 +271,6 @@ A collection of clear and concise examples how to work with CrateDB.
 :class-title: sd-fs-5
 :class-body: sd-text-center
 :class-footer: text-smaller
-
 {material-outlined}`apps;3.5em`
 +++
 Different client libraries used by canonical guestbook demo web applications. 
@@ -239,15 +283,20 @@ Different client libraries used by canonical guestbook demo web applications.
 
 ----
 
-**Resources:** [Academy] • [Blog] • [Community] • [Customers] • [GitHub] • [Support]
+**Resources:**
+[Academy] • [Blog] • [Community] • [Customers] • [Examples] • 
+[GitHub] • [Guide] • [Support]
 
 
 [Academy]: https://learn.cratedb.com/
 [Blog]: https://cratedb.com/blog
 [Community]: https://community.cratedb.com/
 [Customers]: https://cratedb.com/customers
+[Examples]: https://github.com/crate/cratedb-examples
 [GitHub]: https://github.com/crate
+[Guide]: https://cratedb.com/docs/guide/
 [HTTP protocol]: https://en.wikipedia.org/wiki/HTTP
+[Integrations]: #integrate
 [JDBC]: https://en.wikipedia.org/wiki/Java_Database_Connectivity 
 [ODBC]: https://en.wikipedia.org/wiki/Open_Database_Connectivity
 [PostgreSQL wire protocol]: https://www.postgresql.org/docs/current/protocol.html

--- a/docs/home/index.md
+++ b/docs/home/index.md
@@ -1,0 +1,252 @@
+---
+orphan: true
+---
+
+
+<style>
+/* Cards with links */
+.sd-hide-link-text {
+  height: 0;
+}
+</style>
+
+
+
+# CrateDB Documentation
+
+Documentation overview for CrateDB and CrateDB Cloud.
+<br>
+Reference manuals, tutorials, example code, and more.
+
+::::{grid} 1 1 2 2
+:margin: 1
+:padding: 2
+
+:::{grid-item-card} {material-outlined}`rocket_launch;1.7em` CrateDB Cloud
+:link: cloud-docs-index
+:link-type: ref
+:link-alt: CrateDB Cloud
+:padding: 2
+:class-title: sd-fs-5
+
+CrateDB Cloud is a fully managed, terabyte-scale, and cost-effective analytics
+database that lets you run analytics over vast amounts of data in near real time,
+even with complex queries.
+
+CrateDB Cloud is an SQL database service for enterprise data warehouse workloads,
+that works across clouds and scales with your data.
+:::
+
+:::{grid-item-card} {material-outlined}`auto_stories;1.7em` Database Manual
+:link: cloud-docs-index
+:link-type: ref
+:link-alt: CrateDB Cloud
+:padding: 2
+:class-title: sd-fs-5
+
+CrateDB is a distributed and scalable SQL database for storing and
+analyzing massive amounts of data in near real-time, even with complex queries.
+It is PostgreSQL-compatible, and based on Lucene. 
+
+CrateDB is an open source multi-model database for time series, documents
+and vectors, combining the simplicity of SQL with the scalability of a
+distributed architecture.
+:::
+
+::::
+
+
+::::{grid} 1
+:margin: 1
+:padding: 2
+
+:::{grid-item-card} {material-outlined}`link;1.7em` Client Libraries
+:link: https://cratedb.com/docs/crate/clients-tools/en/latest/connect/
+:link-alt: CrateDB Client Drivers and Libraries
+:padding: 2
+:class-title: sd-fs-5
+
+Connect your applications to CrateDB and CrateDB Cloud, using database
+drivers, libraries, adapters, connectors, and dialects.
+
+CrateDB supports both the [HTTP protocol] and the [PostgreSQL wire protocol],
+which ensures that many clients that work with PostgreSQL, will also work with
+CrateDB. Through corresponding drivers, CrateDB is compatible with [ODBC],
+[JDBC], and other database API specifications.
+
+:::
+
+::::
+
+
+## Guides and Tutorials 
+
+
+:::{rubric} Introduction
+:::
+Learn about the fundamentals of CrateDB and its utility applications.
+
+::::{grid} 2 3 3 3
+:padding: 0
+
+:::{grid-item-card} Getting Started
+:link: https://cratedb.com/docs/guide/getting-started.html
+:link-alt: Getting started with CrateDB
+:padding: 3
+:class-card: sd-pt-3
+:class-title: sd-fs-5
+:class-body: sd-text-center
+:class-footer: text-smaller
+
+{material-outlined}`lightbulb;3.5em`
++++
+Learn how to interact with the database for the first time.
+:::
+
+
+:::{grid-item-card} Admin UI
+:link: https://cratedb.com/docs/crate/admin-ui/
+:link-alt: The CrateDB Admin UI
+:padding: 3
+:class-card: sd-pt-3
+:class-title: sd-fs-5
+:class-body: sd-text-center
+:class-footer: text-smaller
+
+{material-outlined}`admin_panel_settings;3.5em`
++++
+Learn about CrateDB's included web administration interface.
+:::
+
+
+:::{grid-item-card} Crash CLI
+:link: https://cratedb.com/docs/crate/crash/
+:link-alt: The Crash CLI
+:padding: 3
+:class-card: sd-pt-3
+:class-title: sd-fs-5
+:class-body: sd-text-center
+:class-footer: text-smaller
+
+{material-outlined}`terminal;3.5em`
++++
+A command-line interface (CLI) tool for working with CrateDB.
+:::
+
+::::
+
+
+:::{rubric} Drivers and Integrations
+:::
+
+Learn about database client libraries, drivers, adapters, connectors,
+and integrations with 3rd-party applications.
+
+::::{grid} 2 3 3 3
+:padding: 0
+
+:::{grid-item-card} Ecosystem Catalog
+:link: catalog
+:link-type: ref
+:link-alt: Ecosystem Catalog
+:padding: 3
+:class-card: sd-pt-3
+:class-title: sd-fs-5
+:class-body: sd-text-center
+:class-footer: text-smaller
+
+{material-outlined}`category;3.5em`
++++
+Discover integrations and solutions from the open source community and CrateDB partners.
+:::
+
+
+:::{grid-item-card} Integration Tutorials I
+:link: integrate
+:link-type: ref
+:link-alt: Integration Tutorials I
+:padding: 3
+:class-card: sd-pt-3
+:class-title: sd-fs-5
+:class-body: sd-text-center
+:class-footer: text-smaller
+
+{material-outlined}`school;3.5em`
++++
+Learn about the variety of options to connect and integrate with 3rd-party applications.
+:::
+
+
+:::{grid-item-card} Integration Tutorials II
+:link: https://community.cratedb.com/t/overview-of-cratedb-integration-tutorials/1015
+:link-alt: Integration Tutorials II
+:padding: 3
+:class-card: sd-pt-3
+:class-title: sd-fs-5
+:class-body: sd-text-center
+:class-footer: text-smaller
+
+{material-outlined}`local_library;3.5em`
++++
+Integration-focused tutorials to help you use CrateDB together with other tools and libraries.
+:::
+
+
+::::
+
+
+## Examples
+
+Learn how to use CrateDB by digesting concise examples.
+
+::::{grid} 2 3 3 3
+:padding: 0
+
+:::{grid-item-card} CrateDB Examples 
+:link: https://github.com/crate/cratedb-examples
+:link-alt: CrateDB Examples
+:padding: 3
+:class-card: sd-pt-3
+:class-title: sd-fs-5
+:class-body: sd-text-center
+:class-footer: text-smaller
+
+{material-outlined}`play_circle;3.5em`
++++
+A collection of clear and concise examples how to work with CrateDB.
+:::
+
+:::{grid-item-card} Sample Apps 
+:link: https://github.com/crate/crate-sample-apps/
+:link-alt: CrateDB Sample Apps
+:padding: 3
+:class-card: sd-pt-3
+:class-title: sd-fs-5
+:class-body: sd-text-center
+:class-footer: text-smaller
+
+{material-outlined}`apps;3.5em`
++++
+Different client libraries used by canonical guestbook demo web applications. 
+:::
+
+::::
+
+
+<br>
+
+----
+
+**Resources:** [Academy] • [Blog] • [Community] • [Customers] • [GitHub] • [Support]
+
+
+[Academy]: https://learn.cratedb.com/
+[Blog]: https://cratedb.com/blog
+[Community]: https://community.cratedb.com/
+[Customers]: https://cratedb.com/customers
+[GitHub]: https://github.com/crate
+[HTTP protocol]: https://en.wikipedia.org/wiki/HTTP
+[JDBC]: https://en.wikipedia.org/wiki/Java_Database_Connectivity 
+[ODBC]: https://en.wikipedia.org/wiki/Open_Database_Connectivity
+[PostgreSQL wire protocol]: https://www.postgresql.org/docs/current/protocol.html
+[Support]: https://cratedb.com/support/

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-crate-docs-theme
+crate-docs-theme==0.33.1.dev0
 
 # cache-buster-20240305
 # Remark: Used for PyPI download cache busting on GHA.


### PR DESCRIPTION
## About
There was a proposal to have a dedicated landing page for the documentation section at https://cratedb.com/docs/, which should refer to the most relevant 1st-level pillars of our documentation tree.

**Preview:** [Docs Home](https://cratedb-guide--94.org.readthedocs.build/home/)

## Details
This page is special, should not necessarily be part of the content tree, that's why it is flagged as **orphaned**, concerning Sphinx technicalities.

The aim is to slot this page into the URL namespace as a landing page for all the documentation based on Sphinx, straight at https://cratedb.com/docs/, by using corresponding Nginx configuration snippets.

## References
- https://github.com/crate/tech-content/issues/105

## Thoughts
This is just a quick proposal, which most definitively has flaws on different details. It intends to give you a first idea how this page could look like, mostly using the most venerable visual design element we are currently using across the board, a **card** component, applied in multiple variations, because otherwise it would be too boring.

Please suggest both wording improvements, and also please have your voice on general structure and layout, in terms of guidance, and how you would like to see the document being re-shaped. Please take your time, or, alternatively, if you roughly agree, acknowledge early, in order to postpone further editing to subsequent iterations, by shipping early, and iterating progressively.

## Contributions
We will be extraordinarily happy to receive your feedback on this PR, or at https://github.com/crate/tech-content/issues/105, when applicable. If you intend to work on another variant of this page hands-on, please derive a new feature branch from `collab/welcome`, and submit your patches creating a separate PR, which will also give you a dedicated preview rendering on RTD.

If you want to suggest different icons for the relevant items, please head over to https://fonts.google.com/icons.

/cc @seut, @matriv, @proddata, @simonprickett, @surister, @karynzv, @hlcianfagna, @hammerhead, @msbt, @matkuliak, @ckurze, @stephanec76, @geragray
