### PR TITLE
Integration/CDC: Add dedicated page about CDC matters

### DIFF
--- a/docs/_include/links.md
+++ b/docs/_include/links.md
@@ -1,9 +1,12 @@
+[Amazon DynamoDB Streams]: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.html
 [BM25]: https://en.wikipedia.org/wiki/Okapi_BM25
 [cloud-datashader-colab]: https://colab.research.google.com/github/crate/cratedb-examples/blob/amo/cloud-datashader/topic/timeseries/explore/cloud-datashader.ipynb
 [cloud-datashader-github]: https://github.com/crate/cratedb-examples/blob/amo/cloud-datashader/topic/timeseries/explore/cloud-datashader.ipynb
 [CTE]: inv:crate-reference#sql_dql_with
+[CrateDB's PostgreSQL interface]: inv:crate-reference#interface-postgresql
 [Datashader]: https://datashader.org/
 [Dynamic Database Schemas]: https://cratedb.com/product/features/dynamic-schemas
+[DynamoDB CDC Relay]: https://cratedb-toolkit.readthedocs.io/io/dynamodb/cdc.html
 [Geospatial Data Model]: https://cratedb.com/data-model/geospatial
 [Geospatial Database]: https://cratedb.com/geospatial-spatial-database
 [HNSW]: https://en.wikipedia.org/wiki/Hierarchical_navigable_small_world
@@ -21,6 +24,8 @@
 [langchain-rag-sql-binder]: https://mybinder.org/v2/gh/crate/cratedb-examples/main?labpath=topic%2Fmachine-learning%2Fllm-langchain%2Fcratedb-vectorstore-rag-openai-sql.ipynb
 [langchain-rag-sql-colab]: https://colab.research.google.com/github/crate/cratedb-examples/blob/main/topic/machine-learning/llm-langchain/cratedb-vectorstore-rag-openai-sql.ipynb
 [langchain-rag-sql-github]: https://github.com/crate/cratedb-examples/blob/main/topic/machine-learning/llm-langchain/cratedb-vectorstore-rag-openai-sql.ipynb
+[MongoDB CDC Relay]: https://cratedb-toolkit.readthedocs.io/io/mongodb/cdc.html
+[MongoDB Change Streams]: https://www.mongodb.com/docs/manual/changeStreams/
 [Multi-model Database]: https://cratedb.com/solutions/multi-model-database
 [nearest neighbor search]: https://en.wikipedia.org/wiki/Nearest_neighbor_search
 [Nested Data Structure]: https://cratedb.com/product/features/nested-data-structure
@@ -28,8 +33,8 @@
 [RANK]: inv:crate-reference#window-functions-rank
 [Relational Database]: https://cratedb.com/solutions/relational-database
 [TF–IDF]: https://en.wikipedia.org/wiki/Tf%E2%80%93idf
+[Replicating CDC events from DynamoDB to CrateDB]: https://cratedb.com/blog/replicating-cdc-events-from-dynamodb-to-cratedb
 [timeseries-queries-and-visualization-colab]: https://colab.research.google.com/github/crate/cratedb-examples/blob/main/topic/timeseries/timeseries-queries-and-visualization.ipynb
 [timeseries-queries-and-visualization-github]: https://github.com/crate/cratedb-examples/blob/main/topic/timeseries/timeseries-queries-and-visualization.ipynb
 [Vector Database (Product)]: https://cratedb.com/solutions/vector-database
 [Vector Database]: https://en.wikipedia.org/wiki/Vector_database
-

--- a/docs/feature/relational/index.md
+++ b/docs/feature/relational/index.md
@@ -51,9 +51,7 @@ very beginning.
 ```
 - {ref}`sql`
 - {ref}`query`
-- {ref}`fulltext`
-- {ref}`geospatial`
-- {ref}`vector`
+- {ref}`search-overview`
 
 {tags-primary}`SQL`
 {tags-primary}`JOIN`

--- a/docs/integrate/cdc/index.md
+++ b/docs/integrate/cdc/index.md
@@ -1,0 +1,64 @@
+(cdc)=
+# Change Data Capture (CDC)
+
+:::{include} /_include/links.md
+:::
+
+:::{div}
+You have a variety of options to connect and integrate with 3rd-party
+CDC applications, mostly using [CrateDB's PostgreSQL interface].
+
+CrateDB also provides a few native adapter components, that can be used
+to leverage its advanced features. 
+
+This documentation section lists corresponding CDC applications and
+frameworks which can be used together with CrateDB, and outlines how
+to use them optimally.
+Please also have a look at support for [generic ETL](#etl) solutions.
+:::
+
+## Debezium
+Debezium is an open source distributed platform for change data capture (CDC).
+It is built on top of Apache Kafka, a distributed streaming platform. It allows
+to capture changes on a source database system, mostly OLTP, and replicate them
+to another system, mostly to run OLAP workloads on the data.
+
+Debezium provides connectors for MySQL/MariaDB, MongoDB, PostgreSQL, Oracle,
+SQL Server, IBM DB2, Cassandra, Vitess, Spanner, JDBC, and Informix.
+
+- [Tutorial: Replicating data to CrateDB with Debezium and Kafka]
+- [Webinar: How to replicate data from other databases to CrateDB with Debezium and Kafka]
+
+## DynamoDB
+:::{div}
+Tap into [Amazon DynamoDB Streams], to replicate CDC events from DynamoDB into CrateDB,
+with support for CrateDB's container data types.
+- {hyper-open}`Documentation <[DynamoDB CDC Relay]>`
+- {hyper-read-more}`Blog <[Replicating CDC events from DynamoDB to CrateDB]>`
+:::
+
+## MongoDB
+:::{div}
+Tap into [MongoDB Change Streams], to relay CDC events from MongoDB into CrateDB,
+with support for CrateDB's container data types.
+- {hyper-open}`Documentation <[MongoDB CDC Relay]>`
+:::
+
+## StreamSets
+
+The [StreamSets Data Collector] is a lightweight and powerful engine that
+allows you to build streaming, batch and change-data-capture (CDC) pipelines
+that can ingest and transform data from a variety of different sources.
+
+StreamSets Data Collector Engine makes it easy to run data pipelines from Kafka,
+Oracle, Salesforce, JDBC, Hive, and more to Snowflake, Databricks, S3, ADLS, Kafka
+and more. Data Collector Engine runs on-premises or any cloud, wherever your data
+lives.
+
+- {ref}`streamsets`
+
+
+
+[Tutorial: Replicating data to CrateDB with Debezium and Kafka]: https://community.cratedb.com/t/replicating-data-to-cratedb-with-debezium-and-kafka/1388
+[Webinar: How to replicate data from other databases to CrateDB with Debezium and Kafka]: https://cratedb.com/resources/webinars/lp-wb-debezium-kafka
+[StreamSets Data Collector]: https://www.softwareag.com/en_corporate/platform/integration-apis/data-collector-engine.html

--- a/docs/integrate/etl/index.md
+++ b/docs/integrate/etl/index.md
@@ -1,15 +1,20 @@
 (etl)=
 (io)=
 (import-export)=
-
 # Load and Export
 
+:::{include} /_include/links.md
+:::
+
+:::{div}
 You have a variety of options to connect and integrate with 3rd-party
 ETL applications, mostly using [CrateDB's PostgreSQL interface].
+:::
 
 This documentation section lists corresponding ETL applications and
 frameworks which can be used together with CrateDB, and outlines how
 to use them optimally.
+Please also have a look at support for [](#cdc) solutions.
 
 
 ## Apache Airflow / Astronomer
@@ -82,11 +87,6 @@ azure-functions
 
 - [Using dbt with CrateDB]
 
-
-## Debezium
-
-- [Tutorial: Replicating data to CrateDB with Debezium and Kafka]
-- [Webinar: How to replicate data from other databases to CrateDB with Debezium and Kafka]
 
 ## InfluxDB
 
@@ -170,7 +170,6 @@ streamsets
 [CrateDB and Apache Airflow: Building a data ingestion pipeline]: https://community.cratedb.com/t/cratedb-and-apache-airflow-building-a-data-ingestion-pipeline/926 
 [CrateDB Apache Hop Bulk Loader transform]: https://hop.apache.org/manual/latest/pipeline/transforms/cratedb-bulkloader.html
 [CrateDB dialect for Apache Hop]: https://hop.apache.org/manual/latest/database/databases/cratedb.html
-[CrateDB's PostgreSQL interface]: inv:crate-reference#interface-postgresql
 [Data Ingestion using Kafka and Kafka Connect]: https://cratedb.com/docs/crate/howtos/en/latest/integrations/kafka-connect.html
 [ETL pipeline using Apache Airflow with CrateDB (Source)]: https://github.com/astronomer/astro-cratedb-blogpost
 [ETL with Astro and CrateDB Cloud in 30min - fully up in the cloud]: https://www.astronomer.io/blog/run-etlelt-with-airflow-and-cratedb/
@@ -182,9 +181,7 @@ streamsets
 [meltano-target-cratedb]: https://github.com/crate-workbench/meltano-target-cratedb
 [Run an ETL pipeline with CrateDB and data quality checks]: https://registry.astronomer.io/dags/etl_pipeline/
 [Setting up data pipelines with CrateDB and Kestra]: https://community.cratedb.com/t/setting-up-data-pipelines-with-cratedb-and-kestra-io/1400
-[Tutorial: Replicating data to CrateDB with Debezium and Kafka]: https://community.cratedb.com/t/replicating-data-to-cratedb-with-debezium-and-kafka/1388
 [Updating stock market data automatically with CrateDB and Apache Airflow]: https://community.cratedb.com/t/updating-stock-market-data-automatically-with-cratedb-and-apache-airflow/1304
 [Using Apache Hop with CrateDB]: https://community.cratedb.com/t/using-apache-hop-with-cratedb/1754
 [Using dbt with CrateDB]: https://community.cratedb.com/t/using-dbt-with-cratedb/1566
 [Using SQL Server Integration Services with CrateDB]: https://github.com/crate/cratedb-examples/tree/main/application/microsoft-ssis
-[Webinar: How to replicate data from other databases to CrateDB with Debezium and Kafka]: https://cratedb.com/resources/webinars/lp-wb-debezium-kafka

--- a/docs/integrate/etl/streamsets.rst
+++ b/docs/integrate/etl/streamsets.rst
@@ -154,4 +154,4 @@ You can verify that the data is now in CrateDB:
 .. _CrateDB JDBC driver: https://cratedb.com/docs/jdbc/
 .. _external libraries: https://streamsets.com/documentation/datacollector/latest/help/datacollector/UserGuide/Configuration/ExternalLibs.html
 .. _New York taxi dataset: https://streamsets.com/documentation/datacollector/latest/help/datacollector/UserGuide/Tutorial/BeforeYouBegin.html?hl=nyc_taxi_data/
-.. _StreamSets Data Collector: https://streamsets.com/products/dataops-platform-2/data-collector-engine/
+.. _StreamSets Data Collector: https://www.softwareag.com/en_corporate/platform/integration-apis/data-collector-engine.html

--- a/docs/integrate/index.md
+++ b/docs/integrate/index.md
@@ -16,6 +16,7 @@ optimally.
 orm
 df
 etl/index
+cdc/index
 metrics/index
 visualize/index
 bi/index

--- a/docs/migrate/rockset/index.md
+++ b/docs/migrate/rockset/index.md
@@ -1,4 +1,8 @@
+(rockset)=
 # Welcome Rockset Developers
+
+:::{include} /_include/links.md
+:::
 
 <style>
 /* Cards with links */
@@ -276,12 +280,14 @@ Migrate Queries <query>
 :::
 :::{rubric} Migrating workloads from Rockset to CrateDB
 :::
-- Replicating CDC Events from DynamoDB into CrateDB. \
-  {hyper-read-more}`Blog <[Replicating CDC Events from DynamoDB to CrateDB]>`
+- [Amazon DynamoDB Streams]: Replicate CDC events from DynamoDB into CrateDB. \
   {hyper-open}`Documentation <[DynamoDB CDC Relay]>`
+  {hyper-read-more}`Blog <[Replicating CDC events from DynamoDB to CrateDB]>`
 
-- Relaying MongoDB Change Streams into CrateDB. \
+- [MongoDB Change Streams]: Relay CDC events from MongoDB into CrateDB. \
   {hyper-open}`Documentation <[MongoDB CDC Relay]>`
+
+- More information about [](#cdc) with CrateDB.
 ::::
 
 ::::{grid-item-card}
@@ -316,7 +322,6 @@ and Python example programs.
 
 [Advanced Querying]: project:#advanced-querying
 [All features of CrateDB at a glance]: project:#all-features
-[Amazon DynamoDB Streams]: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.html
 [Amazon Kinesis Data Streams]: https://aws.amazon.com/kinesis/
 [Apache/Confluent Kafka Streams]: https://kafka.apache.org/documentation/streams/
 [automatically indexes all your data]: project:#hybrid-index
@@ -327,15 +332,12 @@ and Python example programs.
 [CrateDB Editions]: https://cratedb.com/database/editions
 [CrateDB SQL]: project:#sql
 [DX]: https://en.wikipedia.org/wiki/User_experience#Developer_experience
-[DynamoDB CDC Relay]: https://cratedb-toolkit.readthedocs.io/io/dynamodb/cdc.html
 [Ecosystem Catalog]: https://cratedb.com/docs/crate/clients-tools/
 [Integration Tutorials I]: inv:#integrate
 [Integration Tutorials II]: https://community.cratedb.com/t/overview-of-cratedb-integration-tutorials/1015
 [migration]: https://cratedb.com/migrations/rockset
 [MongoDB Atlas Change Streams]: https://www.mongodb.com/docs/manual/changeStreams/
-[MongoDB CDC Relay]: https://cratedb-toolkit.readthedocs.io/io/mongodb/cdc.html
 [open-source code base]: https://github.com/crate/crate
-[Replicating CDC Events from DynamoDB to CrateDB]: https://cratedb.com/blog/replicating-cdc-events-from-dynamodb-to-cratedb
 [Rockset]: https://rockset.com/product/
 [Rockset's pricing examples]: https://docs.rockset.com/documentation/docs/billing#pricing-examples
 [Rockset HTTP API Adapter for CrateDB]: https://cratedb-toolkit.readthedocs.io/adapter/rockset.html


### PR DESCRIPTION
## About
Building upon GH-107, and including a few other resources, this patch adds a dedicated page about Change Data Capture (CDC) to the documentation.

## Preview
https://cratedb-guide--108.org.readthedocs.build/integrate/cdc/

## What's Inside
- Absorb Debezium item from the ETL section
- Add item about CrateDB-native DynamoDB CDC
- Add item about CrateDB-native MongoDB CDC
- Reference item about StreamSets Data Collector in the ETL section

/cc @ckurze, @geragray 