### PR TITLE
Install: Clarify tarball installation on macOS

### DIFF
--- a/docs/install/tarball.rst
+++ b/docs/install/tarball.rst
@@ -9,24 +9,37 @@ This section of the documentation outlines how to use the release archives to
 install CrateDB. The walkthrough is suitable to install and run CrateDB on
 `Unix-like`_ systems, for example Linux and macOS.
 
-#. Download the latest `CrateDB release archive`_. Please make sure to select
+1. Download the latest `CrateDB release archive`_. Please make sure to select
    the right release archive matching your system.
 
-#. Once downloaded, extract the archive either using your favorite terminal or
+2. Once downloaded, extract the archive either using your favorite terminal or
    command line shell or by using a GUI tool like `7-Zip`_::
 
        # Extract tarball on Unix-like systems
        tar -xzf crate-*.tar.gz
 
-#. On the terminal, change into the extracted ``crate`` directory::
+3. On the terminal, change into the extracted ``crate`` directory::
 
        cd crate-*
 
-#. Run a CrateDB single-node instance on the local network interface::
+4. Run a CrateDB single-node instance on the local network interface::
 
        ./bin/crate
 
-#. In order to stop CrateDB again, use :kbd:`ctrl-c`.
+.. NOTE::
+
+    When installing a specific version of CrateDB from tarball on a macOS
+    system for the first time, it is possible that you will encounter error:
+    **"java" cannot be openeded because developer cannot be verified.**
+
+    This is expected and can be fixed in your system settings:
+      - Navigate to **System Preferences** -> **Security and Privacy**
+      - On the page you will see an **Allow Anyway** button for "java"
+      - After confirming, run the ``/bin/crate`` command again. You will be
+        asked to confirm once more with **Open** button. After that CrateDB
+        will run as expected.
+
+5. In order to stop CrateDB again, use :kbd:`ctrl-c`.
 
 .. SEEALSO::
 

--- a/docs/install/tarball.rst
+++ b/docs/install/tarball.rst
@@ -29,7 +29,7 @@ install CrateDB. The walkthrough is suitable to install and run CrateDB on
 .. NOTE::
 
     When installing a specific version of CrateDB from tarball on a macOS
-    system for the first time, it is possible that you will encounter error:
+    system for the first time, it is possible that you will encounter an error like:
     **"java" cannot be openeded because developer cannot be verified.**
 
     This is expected and can be fixed in your system settings:


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Clarify that on macOS permissions need to be added when running a specific version from tarball for the first time 

## Preview
https://cratedb-guide--111.org.readthedocs.build/install/tarball.html#install-macos

## Checklist

 - [x] Link to issue this PR refers to (if applicable): https://github.com/crate/tech-writing/issues/426
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
