### PR TITLE
Chore: Fix broken Markdown link on integrate/etl/index

### DIFF
--- a/docs/_include/links.md
+++ b/docs/_include/links.md
@@ -32,6 +32,7 @@
 [query DSL based on JSON]: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
 [RANK]: inv:crate-reference#window-functions-rank
 [Relational Database]: https://cratedb.com/solutions/relational-database
+[Replicating data to CrateDB with Debezium and Kafka]: https://community.cratedb.com/t/replicating-data-to-cratedb-with-debezium-and-kafka/1388
 [TF–IDF]: https://en.wikipedia.org/wiki/Tf%E2%80%93idf
 [Replicating CDC events from DynamoDB to CrateDB]: https://cratedb.com/blog/replicating-cdc-events-from-dynamodb-to-cratedb
 [timeseries-queries-and-visualization-colab]: https://colab.research.google.com/github/crate/cratedb-examples/blob/main/topic/timeseries/timeseries-queries-and-visualization.ipynb

--- a/docs/integrate/cdc/index.md
+++ b/docs/integrate/cdc/index.md
@@ -25,9 +25,10 @@ to another system, mostly to run OLAP workloads on the data.
 
 Debezium provides connectors for MySQL/MariaDB, MongoDB, PostgreSQL, Oracle,
 SQL Server, IBM DB2, Cassandra, Vitess, Spanner, JDBC, and Informix.
-
-- [Tutorial: Replicating data to CrateDB with Debezium and Kafka]
-- [Webinar: How to replicate data from other databases to CrateDB with Debezium and Kafka]
+:::{div}
+- Tutorial: [Replicating data to CrateDB with Debezium and Kafka]
+- Webinar: [How to replicate data from other databases to CrateDB with Debezium and Kafka]
+:::
 
 ## DynamoDB
 :::{div}
@@ -59,6 +60,5 @@ lives.
 
 
 
-[Tutorial: Replicating data to CrateDB with Debezium and Kafka]: https://community.cratedb.com/t/replicating-data-to-cratedb-with-debezium-and-kafka/1388
-[Webinar: How to replicate data from other databases to CrateDB with Debezium and Kafka]: https://cratedb.com/resources/webinars/lp-wb-debezium-kafka
+[How to replicate data from other databases to CrateDB with Debezium and Kafka]: https://cratedb.com/resources/webinars/lp-wb-debezium-kafka
 [StreamSets Data Collector]: https://www.softwareag.com/en_corporate/platform/integration-apis/data-collector-engine.html

--- a/docs/integrate/etl/index.md
+++ b/docs/integrate/etl/index.md
@@ -55,11 +55,11 @@ Tutorials and resources about configuring the managed variants, Astro and CrateD
 
 
 ## Apache Kafka
-
-- [Data Ingestion using Kafka and Kafka Connect]
-- [Executable stack: Apache Kafka, Apache Flink, and CrateDB]
-- [Tutorial: Replicating data to CrateDB with Debezium and Kafka]
-
+:::{div}
+- {ref}`kafka-connect`
+- [Executable stack with Apache Kafka, Apache Flink, and CrateDB]
+- [Replicating data to CrateDB with Debezium and Kafka]
+:::
 ```{toctree}
 :hidden:
 
@@ -170,11 +170,10 @@ streamsets
 [CrateDB and Apache Airflow: Building a data ingestion pipeline]: https://community.cratedb.com/t/cratedb-and-apache-airflow-building-a-data-ingestion-pipeline/926 
 [CrateDB Apache Hop Bulk Loader transform]: https://hop.apache.org/manual/latest/pipeline/transforms/cratedb-bulkloader.html
 [CrateDB dialect for Apache Hop]: https://hop.apache.org/manual/latest/database/databases/cratedb.html
-[Data Ingestion using Kafka and Kafka Connect]: https://cratedb.com/docs/crate/howtos/en/latest/integrations/kafka-connect.html
 [ETL pipeline using Apache Airflow with CrateDB (Source)]: https://github.com/astronomer/astro-cratedb-blogpost
 [ETL with Astro and CrateDB Cloud in 30min - fully up in the cloud]: https://www.astronomer.io/blog/run-etlelt-with-airflow-and-cratedb/
 [Examples about working with CrateDB and Meltano]: https://github.com/crate/cratedb-examples/tree/amo/meltano/framework/singer-meltano
-[Executable stack: Apache Kafka, Apache Flink, and CrateDB]: https://github.com/crate/cratedb-examples/tree/main/application/apache-kafka-flink
+[Executable stack with Apache Kafka, Apache Flink, and CrateDB]: https://github.com/crate/cratedb-examples/tree/main/application/apache-kafka-flink
 [Implementing a data retention policy in CrateDB using Apache Airflow]: https://community.cratedb.com/t/implementing-a-data-retention-policy-in-cratedb-using-apache-airflow/913 
 [Ingesting MQTT messages into CrateDB using Node-RED]: https://community.cratedb.com/t/ingesting-mqtt-messages-into-cratedb-using-node-red/803
 [meltano-tap-cratedb]: https://github.com/crate-workbench/meltano-tap-cratedb


### PR DESCRIPTION
## Problem
A broken Markdown/MyST link.

> ![image](https://github.com/user-attachments/assets/cf8af085-41f0-4e56-8fc5-a3fd8d5d4367)
>
> -- https://cratedb.com/docs/guide/integrate/etl/index.html#apache-kafka

## Thoughts
Why doesn't the link checker probe them correctly? Most probably, MyST would be responsible in one way or another?
