### PR TITLE
Chore: Update designated pytest package to be `pytest-cratedb`

### DIFF
--- a/docs/integrate/testing.md
+++ b/docs/integrate/testing.md
@@ -10,14 +10,14 @@ integration testing with CrateDB.
 
 The popular [pytest] framework makes it easy to write small tests, but it
 also supports complex functional testing for applications and libraries.
-The [pytest-crate] package manages CrateDB instances for running integration
+The [pytest-cratedb] package manages CrateDB instances for running integration
 tests against them.
 
 It is based on [cr8](#cr8) for the heavy lifting, and additionally provides
 the `crate`, `crate_execute`, and `crate_cursor` pytest fixtures for
 developer convenience.
 
-- [Using "pytest-crate" with CrateDB and pytest]
+- [Using "pytest-cratedb" with CrateDB and pytest]
 
 
 (cr8)=
@@ -48,12 +48,12 @@ CrateDB provides Testcontainers implementations for both Java and Python.
 
 [cr8]: https://pypi.org/project/cr8/
 [pytest]: https://docs.pytest.org/
-[pytest-crate]: https://pypi.org/project/pytest-crate/
+[pytest-cratedb]: https://pypi.org/project/pytest-cratedb/
 [run-crate]: https://pypi.org/project/cr8/#run-crate
 [Testcontainers]: https://testcontainers.com/
 [unittest]: https://docs.python.org/3/library/unittest.html
 [Using "cr8" test layers with CrateDB and unittest]: https://github.com/crate/cratedb-examples/tree/main/testing/native/python-unittest
-[Using "pytest-crate" with CrateDB and pytest]: https://github.com/crate/cratedb-examples/tree/main/testing/native/python-pytest
+[Using "pytest-cratedb" with CrateDB and pytest]: https://github.com/crate/cratedb-examples/tree/main/testing/native/python-pytest
 [Using "Testcontainers for Java" with CrateDB]: https://github.com/crate/cratedb-examples/tree/main/testing/testcontainers/java
 [Using "Testcontainers for Python" with CrateDB and pytest]: https://github.com/crate/cratedb-examples/tree/main/testing/testcontainers/python-pytest
 [Using "Testcontainers for Python" with CrateDB and unittest]: https://github.com/crate/cratedb-examples/tree/main/testing/testcontainers/python-unittest


### PR DESCRIPTION
## About
pytest-cratedb has been modernized recently, and already works well on a few projects. Let's also advertise it here.

## Preview
https://cratedb-guide--128.org.readthedocs.build/integrate/testing.html#python-pytest
