### PR TITLE
ML/LlamaIndex: Add section about example program accompanying tutorial

### DIFF
--- a/docs/domain/index.md
+++ b/docs/domain/index.md
@@ -120,8 +120,8 @@ analysis, data visualization, and machine learning.
 Learn how to integrate CrateDB with machine learning frameworks and tools.
 +++
 **What's inside:**
-Use CrateDB with LangChain, MLflow, PyCaret, scikit-learn,
-and TensorFlow.
+Use CrateDB with LangChain, LlamaIndex, MLflow, PyCaret, scikit-learn,
+or TensorFlow.
 :::
 
 

--- a/docs/domain/ml/index.md
+++ b/docs/domain/ml/index.md
@@ -349,6 +349,48 @@ CrateDB supports managing LangChain's conversation history.
 ::::
 
 
+(llamaindex)=
+### LlamaIndex
+
+[LlamaIndex] is a data framework for Large Language Models (LLMs). It comes with
+pre-trained models on massive public datasets such as GPT-4 or Llama 2, and
+provides an interface to external data sources allowing for natural language
+querying on your private data.
+
+Azure Open AI Service is a fully managed service that runs on the Azure global
+infrastructure and allows developers to integrate OpenAI models into their
+applications. Through Azure Open AI API one can easily access a wide range of
+AI models in a scalable and reliable way.
+
+What can you do with LlamaIndex?
+
+- [LlamaIndex: Building a RAG pipeline]
+- [LlamaIndex: Building an Agent]
+- [LlamaIndex: Using Workflows]
+
+::::{info-card}
+:::{grid-item}
+:columns: 9
+**Demo: Using LlamaIndex with OpenAI and CrateDB**
+
+- Connect your CrateDB data to an LLM using OpenAI or Azure OpenAI.
+- Query the database in human language,
+  i.e. query CrateDB in plain English.
+
+{hyper-tutorial}`[LlamaIndex and CrateDB: Tutorial]`
+[![README](https://img.shields.io/badge/Open-README-darkblue?logo=GitHub)][LlamaIndex and CrateDB: Code Examples]
+[![Program on GitHub](https://img.shields.io/badge/Open%20on-GitHub-darkgreen?logo=GitHub)][llamaindex-nlquery-github]
+:::
+:::{grid-item}
+:columns: 3
+{tags-primary}`Fundamentals` \
+{tags-secondary}`LLM` \
+{tags-secondary}`NLP` \
+{tags-secondary}`RAG`
+:::
+::::
+
+
 ```{toctree}
 :hidden:
 
@@ -376,6 +418,13 @@ tensorflow
 [langchain-document-loader-binder]: https://mybinder.org/v2/gh/crate/cratedb-examples/main?labpath=topic%2Fmachine-learning%2Fllm-langchain%2Fdocument_loader.ipynb
 [langchain-document-loader-colab]: https://colab.research.google.com/github/crate/cratedb-examples/blob/main/topic/machine-learning/llm-langchain/document_loader.ipynb
 [langchain-document-loader-github]: https://github.com/crate/cratedb-examples/blob/main/topic/machine-learning/llm-langchain/document_loader.ipynb
+[LlamaIndex]: https://www.llamaindex.ai/framework
+[LlamaIndex: Building a RAG pipeline]: https://docs.llamaindex.ai/en/stable/understanding/rag/
+[LlamaIndex: Building an Agent]: https://docs.llamaindex.ai/en/stable/understanding/agent/
+[LlamaIndex: Using Workflows]: https://docs.llamaindex.ai/en/stable/understanding/workflows/
+[LlamaIndex and CrateDB: Code Examples]: https://github.com/crate/cratedb-examples/tree/main/topic/machine-learning/llama-index
+[LlamaIndex and CrateDB: Tutorial]: https://community.cratedb.com/t/how-to-connect-your-cratedb-data-to-llm-with-llamaindex-and-azure-openai/1612
+[llamaindex-nlquery-github]: https://github.com/crate/cratedb-examples/blob/main/topic/machine-learning/llama-index/main.py
 [Machine Learning and CrateDB: An introduction]: https://cratedb.com/blog/machine-learning-and-cratedb-part-one
 [Machine Learning and CrateDB: Getting Started With Jupyter]: https://cratedb.com/blog/machine-learning-cratedb-jupyter
 [Machine Learning and CrateDB: Experiment Design & Linear Regression]: https://cratedb.com/blog/machine-learning-and-cratedb-part-three-experiment-design-and-linear-regression


### PR DESCRIPTION
## About
@simonprickett recently contributed an example program [^1] that uses [LlamaIndex](https://www.llamaindex.ai/framework), extracted and re-assembled from a tutorial [^2] that has been modernized. Thanks!

[^1]: https://github.com/crate/cratedb-examples/tree/main/topic/machine-learning/llama-index
[^2]: https://community.cratedb.com/t/how-to-connect-your-cratedb-data-to-llm-with-llamaindex-and-azure-openai/1612

## Preview
https://cratedb-guide--132.org.readthedocs.build/domain/ml/index.html#llamaindex

## Review
Please suggest any improvements on wording and beyond which come to mind. Thanks!

/cc @surister 
