### PR TITLE
Domain/Time Series: Improve "Time Series Fundamentals with CrateDB" page

### DIFF
--- a/docs/_include/card/timeseries-dask.md
+++ b/docs/_include/card/timeseries-dask.md
@@ -1,0 +1,27 @@
+::::{info-card}
+
+:::{grid-item}
+:columns: auto 9 9 9
+**Notebook: How to Build Time Series Applications with CrateDB**
+
+This notebook illustrates how to import and work with time series data using
+CrateDB and [Dask DataFrame]s.
+[Dask] is a framework to parallelize operations on pandas data frames.
+ 
+{{ '{}[dask-weather-data-github]'.format(nb_github) }} {{ '{}[dask-weather-data-colab]'.format(nb_colab) }}
+:::
+
+:::{grid-item}
+:columns: 3
+{tags-primary}`Data I/O`
+
+{tags-secondary}`Python`
+{tags-secondary}`Dask`
+{tags-secondary}`SQL`
+:::
+
+::::
+
+
+[Dask]: https://www.dask.org/
+[Dask DataFrame]: https://docs.dask.org/en/stable/dataframe.html

--- a/docs/_include/card/timeseries-intro.md
+++ b/docs/_include/card/timeseries-intro.md
@@ -1,0 +1,44 @@
+:::::{grid} auto 2 2 2
+:margin: 4 4 0 0
+:padding: 0
+:gutter: 2
+
+::::{grid-item-card} {material-outlined}`topic;2em` Time Series: Device Readings with Metadata
+:link: guide:timeseries-objects
+:link-type: ref
+:class-footer: text-smaller
+
+CrateDB supports effective time series analysis with enhanced features
+for fast aggregations.
+
+:::{rubric} What's Inside
+:::
+- Rich data types for storing structured nested data (OBJECT) alongside
+  time series data.
+- A rich set of built-in functions for aggregations.
+- Relational JOIN operations.
+- Common table expressions (CTEs).
++++
+Combine time series data with document data: CrateDB is all you need.
+::::
+
+::::{grid-item-card} {material-outlined}`lightbulb;2em` Time Series: Advanced SQL
+:link: guide:timeseries-analysis-weather
+:link-type: ref
+:class-footer: text-smaller
+CrateDB provides enhanced features for querying time series data.
+
+:::{rubric} What's Inside
+:::
+- Run aggregations with gap filling / interpolation, using common
+  table expressions (CTEs) and LAG / LEAD window functions.
+
+- Find maximum values using the MAX_BY aggregate function, returning
+  the value from one column based on the maximum or minimum value of another
+  column within a group.
++++
+Advanced queries on time series data: CrateDB is all you need.
+::::
+
+
+:::::

--- a/docs/_include/links.md
+++ b/docs/_include/links.md
@@ -7,6 +7,8 @@
 [cloud-datashader-github]: https://github.com/crate/cratedb-examples/blob/amo/cloud-datashader/topic/timeseries/explore/cloud-datashader.ipynb
 [CTE]: inv:crate-reference#sql_dql_with
 [CrateDB's PostgreSQL interface]: inv:crate-reference#interface-postgresql
+[dask-weather-data-colab]: https://colab.research.google.com/github/crate/cratedb-examples/blob/main/topic/timeseries/dask-weather-data-import.ipynb
+[dask-weather-data-github]: https://github.com/crate/cratedb-examples/blob/main/topic/timeseries/dask-weather-data-import.ipynb
 [Datashader]: https://datashader.org/
 [Dynamic Database Schemas]: https://cratedb.com/product/features/dynamic-schemas
 [DynamoDB CDC Relay]: https://cratedb-toolkit.readthedocs.io/io/dynamodb/cdc.html

--- a/docs/domain/timeseries/fundamentals.md
+++ b/docs/domain/timeseries/fundamentals.md
@@ -1,44 +1,34 @@
 (timeseries-basics)=
+(timeseries-fundamentals)=
 # Time Series Fundamentals with CrateDB
+
+:::{include} /_include/links.md
+:::
 
 ## Getting Started
 
-- [](#connect)
-- [](#timeseries-generate)
-- [](#timeseries-normalize)
-- [Financial data collection and processing using pandas]
-- [](#timeseries-analysis)
-- [Load and visualize time series data using CrateDB, SQL, pandas, and Plotly](#plotly)
-- [](project:#timeseries-querying)
-- [](project:#timeseries-with-metadata)
+After evaluating [connectivity options](#connect), you would like to get
+hands-on with CrateDB. We prepared a few introductory tutorials, some of
+them in executable forms, to demonstrate CrateDB's features to work with
+time series data on the spot. You may want to use them as starting points
+for your own explorations.
 
-::::{info-card}
-
-:::{grid-item}
-:columns: auto 9 9 9
-**Notebook: How to Build Time Series Applications with CrateDB**
-
-This notebook illustrates how to import and work with time series data in CrateDB.
-It uses Dask to import data into CrateDB.
-Dask is a framework to parallelize operations on pandas data frames.
- 
-{{ '{}[dask-weather-data-github]'.format(nb_github) }} {{ '{}[dask-weather-data-colab]'.format(nb_colab) }}
+:::{include} /_include/card/timeseries-intro.md
 :::
 
-:::{grid-item}
-:columns: 3
-{tags-primary}`Data I/O`
-
-{tags-secondary}`Python`
-{tags-secondary}`Dask`
-{tags-secondary}`SQL`
+:::{include} /_include/card/timeseries-explore.md
 :::
 
-::::
+:::{include} /_include/card/timeseries-dask.md
+:::
 
 
-## Downsampling and Interpolation
+## Special Features
+Working with time series data needs special feature support to enable
+fluent data workflows.
 
+:::{rubric} Downsampling and Interpolation
+:::
 - [](#downsampling-timestamp-binning)
 - [](#downsampling-lttb)
 - [](#ni-interpolate)
@@ -46,6 +36,8 @@ Dask is a framework to parallelize operations on pandas data frames.
 - [](inv:crate-reference#aggregation-percentile)
 
 ## Operations
+CrateDB provides operational support to store and query large time series data
+efficiently.
 - [](#sharding-partitioning)
 - [CrateDB partitioned table vs. TimescaleDB Hypertable]
 
@@ -66,10 +58,11 @@ learn/query
 learn/with-metadata
 :::
 
+:::{todo}
+Outdated: [](#timeseries-generate), [](#timeseries-normalize), [Financial data collection and processing using pandas]
+:::
 
 
 [CrateDB partitioned table vs. TimescaleDB Hypertable]: https://community.cratedb.com/t/cratedb-partitioned-table-vs-timescaledb-hypertable/1713
-[dask-weather-data-colab]: https://colab.research.google.com/github/crate/cratedb-examples/blob/main/topic/timeseries/dask-weather-data-import.ipynb
-[dask-weather-data-github]: https://github.com/crate/cratedb-examples/blob/main/topic/timeseries/dask-weather-data-import.ipynb
 [Financial data collection and processing using pandas]: https://community.cratedb.com/t/automating-financial-data-collection-and-storage-in-cratedb-with-python-and-pandas-2-0-0/916
 [Interpolating missing time series values]: https://community.cratedb.com/t/interpolating-missing-time-series-values/1010

--- a/docs/domain/timeseries/index.md
+++ b/docs/domain/timeseries/index.md
@@ -17,10 +17,10 @@ PostgreSQL-compatible, and based on Lucene.
 :gutter: 2
 
 
-:::{grid-item-card} {material-outlined}`show_chart;2em` Basics
-:link: timeseries-basics
+:::{grid-item-card} {material-outlined}`show_chart;2em` Fundamentals
+:link: timeseries-fundamentals
 :link-type: ref
-:link-alt: Time series basics with CrateDB
+:link-alt: Time series fundamentals with CrateDB
 
 Basic introductory tutorials about using CrateDB with time series data.
 +++
@@ -43,6 +43,34 @@ anomaly detection, forecasting.
 :::
 
 
+:::{grid-item-card} {material-outlined}`smart_display;2em` Video Tutorials
+:link: timeseries-video
+:link-type: ref
+:link-alt: Video tutorials about time series with CrateDB
+
+Educational videos about time series data and CrateDB.
++++
+**What's inside:**
+Time series introduction. Importing, exporting,
+and analyzing. Industrial applications.
+:::
+
+
+:::{grid-item-card} {material-outlined}`school;2em` Academy » Advanced Time Series
+:link: https://cratedb.com/academy/time-series/
+:link-type: url
+:link-alt: Academy Resources: Advanced Time Series
+
+CrateDB Academy is a learning hub dedicated to empowering data enthusiasts with
+the tools and knowledge to harness the power of CrateDB.
++++
+
+**What's inside:**
+Data manipulation and visualization. Data Storage. Importing.
+Machine Learning on Time Series Data: EDA, Decomposition, AutoML.
+:::
+
+
 :::{grid-item-card} {material-outlined}`manage_history;2em` Long Term Storage
 :link: timeseries-longterm
 :link-type: ref
@@ -58,22 +86,16 @@ Optimizing storage for historic time series data.
 :::
 
 
-:::{grid-item-card} {material-outlined}`smart_display;2em` Video Tutorials
-:link: timeseries-video
-:link-type: ref
-:link-alt: Video tutorials about time series with CrateDB
-
-Educational videos about time series data and CrateDB.
-+++
-**What's inside:**
-Time series introduction. Importing, exporting,
-and analyzing. Industrial applications.
-:::
-
 ::::
 
 
 :::{seealso}
+
+**Domains:**
+[](#metrics-store) •
+[](#analytics) •
+[](#industrial) •
+[](#machine-learning)
 
 **Features:**
 [](#connect) •
@@ -82,11 +104,9 @@ and analyzing. Industrial applications.
 [](#fulltext) •
 [](#geospatial)
 
-**Domains:**
-[](#metrics-store) •
-[](#analytics) •
-[](#industrial) •
-[](#machine-learning)
+**Product:**
+[Time Series Data] •
+[White Paper: Guide for Time Series Data Projects]
 :::
 
 
@@ -98,3 +118,8 @@ Advanced <advanced>
 video
 Long Term Store <longterm>
 :::
+
+
+
+[Time Series Data]: https://cratedb.com/data-model/time-series
+[White Paper: Guide for Time Series Data Projects]: https://cratedb.com/resources/white-papers/lp-wp-time-series-guide

--- a/docs/domain/timeseries/learn/query.md
+++ b/docs/domain/timeseries/learn/query.md
@@ -2,7 +2,7 @@
 (timeseries-analysis-weather)=
 (timeseries-querying)=
 
-# Time Series: Analyzing Weather Data
+# Analyzing Weather Data
 
 CrateDB is a powerful database designed to handle various use cases, one of
 which is managing time series data. Time series data refers to collections of


### PR DESCRIPTION
## About
The [Time Series Fundamentals with CrateDB](https://cratedb.com/docs/guide/domain/timeseries/fundamentals.html) page was very sloppily cobbled together the other day.
This patch intends to provide more structure and tangibility.

## Details
Added references to the CrateDB Academy, a relevant White Paper, and the corresponding product page on the website.

## Preview
- https://cratedb-guide--133.org.readthedocs.build/domain/timeseries/
- https://cratedb-guide--133.org.readthedocs.build/domain/timeseries/fundamentals.html

## Review
Please provide advises in wording and layout, and overall ideas how to improve information conveyance on this topic, either within this PR, or separately, when applicable.

/cc @surister, @ckurze, @geragray 