### PR TITLE
Feature/Connectivity: Rework page

### DIFF
--- a/docs/feature/connectivity/index.md
+++ b/docs/feature/connectivity/index.md
@@ -1,85 +1,149 @@
 (connect)=
 (connectivity)=
 
-
 # Connectivity
 
-All the CrateDB connectivity options at a glance.
+:::{include} /_include/links.md
+:::
+
+:::::{grid}
+:padding: 0
+
+::::{grid-item}
+:class: rubric-slimmer
+:columns: auto 9 9 9
+
+
+:::{rubric} Overview
+:::
+CrateDB connectivity options at a glance.
 
 You have a variety of options to connect to CrateDB, and to integrate it with
 off-the-shelve, 3rd-party, open-source, and proprietary applications.
 
-{tags-primary}`Connect`
-{tags-primary}`Import`
-{tags-primary}`Export`
-{tags-primary}`Extract`
-{tags-primary}`Load`
-{tags-primary}`ETL`
-
-
-## Interfaces and Protocols
-
-CrateDB supports both the [HTTP protocol] and the [PostgreSQL wire protocol],
+:::{rubric} About
+:::
+CrateDB supports both the HTTP protocol and the PostgreSQL wire protocol,
 which ensures that many clients that work with PostgreSQL, will also work with
 CrateDB.
 
-Through corresponding drivers, CrateDB is compatible with [ODBC],
-[JDBC], and other database API specifications.
-By supporting [SQL], CrateDB is compatible with many standard database
+Through corresponding drivers, CrateDB is compatible with JDBC, ODBC,
+and other database API specifications.
+By supporting SQL, CrateDB is compatible with many standard database
 environments out of the box.
 
-- [CrateDB HTTP interface]
-- [CrateDB PostgreSQL interface]
-- [CrateDB SQL protocol]
-
-To learn more, please refer to the documentation sections about supported
-client drivers, libraries, and frameworks, and corresponding tutorials.
-
-
-## Drivers and Integrations
+:::{rubric} Details
+:::
 
 CrateDB provides plenty of connectivity options with database drivers,
 applications, and frameworks, in order to get time series data in and
 out of CrateDB, and to connect to other applications.
 
-- [Drivers and Integrations]
-- [](inv:crate-clients-tools#connect)
-- [](inv:crate-clients-tools#df)
-- [](inv:crate-clients-tools#etl)
-- [](inv:crate-clients-tools#metrics)
+To learn more, please refer to the documentation sections and hands-on
+tutorials about supported client drivers, libraries, and frameworks,
+and how to configure and use them with CrateDB optimally.
+::::
 
-## Tutorials
 
-Hands-on tutorials about CrateDB fundamentals about data I/O, as well as about
-properly configuring and connecting relevant 3rd-party software components to
-work optimally with CrateDB.
+::::{grid-item}
+:class: rubric-slim
+:columns: auto 3 3 3
 
-:::{rubric} Overview
+```{rubric} Reference Manual
+```
+- [HTTP interface]
+- [PostgreSQL interface]
+- [SQL query syntax]
+
+```{rubric} Protocols and API Standards
+```
+- [HTTP protocol]
+- [PostgreSQL wire protocol]
+- [JDBC]
+- [ODBC]
+- [SQL]
+::::
+
+:::::
+
+
+## Synopsis
+
+In order to provide a CrateDB instance for testing purposes, use, for
+example, Docker.
+```shell
+docker run --rm -it --publish=4200:4200 --publish=5432:5432 crate/crate:nightly
+```
+:::{tip}
+The [CrateDB Examples] repository also includes a collection of
+clear and concise examples how to connect to and work with CrateDB,
+using different environments, applications, or frameworks.
 :::
-- [](#integrate)
-- [](#etl)
-- [](#integrate-metrics)
-- [](#performance)
 
-:::{rubric} Community Tutorials
+
+## Learn
+
+::::{grid} 2 3 3 3
+:padding: 0
+
+:::{grid-item-card} Ecosystem Catalog
+:link: catalog
+:link-type: ref
+:link-alt: Ecosystem Catalog
+:padding: 3
+:class-card: sd-pt-3
+:class-title: sd-fs-5
+:class-body: sd-text-center
+:class-footer: text-smaller
+{material-outlined}`category;3.5em`
++++
+Explore all open-source and partner applications and solutions.
 :::
-- [Community Tutorials Overview]
-- [Fundamentals of the COPY FROM statement]
 
-
-:::{todo}
-Bring page into the same shape as the others in this section.
+:::{grid-item-card} Driver Support
+:link: crate-clients-tools:connect
+:link-type: ref
+:link-alt: Driver Support
+:padding: 3
+:class-card: sd-pt-3
+:class-title: sd-fs-5
+:class-body: sd-text-center
+:class-footer: text-smaller
+{material-outlined}`link;3.5em`
++++
+List of HTTP and PostgreSQL client drivers, and tutorials.
 :::
 
+:::{grid-item-card} Integration Tutorials
+:link: integrate
+:link-type: ref
+:link-alt: Integration Tutorials
+:padding: 3
+:class-card: sd-pt-3
+:class-title: sd-fs-5
+:class-body: sd-text-center
+:class-footer: text-smaller
+{material-outlined}`local_library;3.5em`
++++
+Learn how to integrate CrateDB with applications and tools.
+:::
 
-[Community Tutorials Overview]: https://community.cratedb.com/t/overview-of-cratedb-integration-tutorials/1015
-[CrateDB HTTP interface]: inv:crate-reference:*:label#interface-http
-[CrateDB PostgreSQL interface]: inv:crate-reference:*:label#interface-postgresql
-[CrateDB SQL protocol]: inv:crate-reference:*:label#sql
-[Drivers and Integrations]: inv:crate-clients-tools:*:label#index
-[Fundamentals of the COPY FROM statement]: https://community.cratedb.com/t/fundamentals-of-the-copy-from-statement/1178
+::::
+
+
+
+[CrateDB Examples]: https://github.com/crate/cratedb-examples
+[Driver Support]: inv:crate-clients-tools:*:label#connect
+[Ecosystem Catalog]: inv:crate-clients-tools:*:label#index
+[HTTP interface]: inv:crate-reference:*:label#interface-http
 [HTTP protocol]: https://en.wikipedia.org/wiki/HTTP
 [JDBC]: https://en.wikipedia.org/wiki/Java_Database_Connectivity
 [ODBC]: https://en.wikipedia.org/wiki/Open_Database_Connectivity
+[PostgreSQL interface]: inv:crate-reference:*:label#interface-postgresql
 [PostgreSQL wire protocol]: https://www.postgresql.org/docs/current/protocol.html
 [SQL]: https://en.wikipedia.org/wiki/Sql
+[SQL query syntax]: inv:crate-reference:*:label#sql
+
+
+```{include} /_include/styles.html
+```


### PR DESCRIPTION
## Problem
The [Feature » Connectivity](https://cratedb.com/docs/guide/feature/connectivity/) page wasn't in a good shape yet. @kneth discovered that recently.

## Solution
This patch intends to converge the page into the same layout/shape/style like all the others in the "All Features" section, using the same compact backbone made of "Intro", "Synopsis", and "Learn" subsections.

## Preview
https://cratedb-guide--135.org.readthedocs.build/feature/connectivity/

## Review
- _Please visit inline comments._
- We believe the "tabs" approach will not scale, so we diverted using the "dropdowns" approach, currently showing both variants. Please advise.

## Details
This refactors a bit of content from a few sibling pages in crate-clients-tools. [^1]
- https://github.com/crate/crate-clients-tools/tree/main/docs/connect
- https://cratedb.com/docs/crate/clients-tools/en/latest/connect/

Demonstrate two different variants for single-page client-/driver-snippets presentation, one using [tabs](https://sphinx-design.readthedocs.io/en/latest/tabs.html), and another one using [dropdowns](https://sphinx-design.readthedocs.io/en/latest/dropdowns.html).

[^1]: crate-clients-tools might be dissolved in the future, in order to reduce maintenance overhead, so it's a good idea to migrate content gradually.
