### PR TITLE
Theme: Update to `crate-docs-theme>=0.37.0.dev0`, introducing dark mode

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-crate-docs-theme>=0.35.0
+crate-docs-theme>=0.37.0.dev0
 
 # cache-buster-20240305
 # Remark: Used for PyPI download cache busting on GHA.


### PR DESCRIPTION
## About
Use the new theme that introduces dark mode. Thanks, @msbt.

## Preview
https://cratedb-guide--136.org.readthedocs.build/

## References
- https://github.com/crate/crate-docs-theme/pull/546
- https://github.com/crate/crate/pull/17001