### PR TITLE
Feature/Search/Vector: Educate about `VECTOR_SIMILARITY` function

### DIFF
--- a/docs/feature/search/vector/index.md
+++ b/docs/feature/search/vector/index.md
@@ -23,8 +23,8 @@
 :::
 CrateDB can be used as a [vector database] (VDBMS) for storing and retrieving
 vector embeddings based on the FLOAT_VECTOR data type and its accompanying
-KNN_MATCH function, effectively conducting HNSW semantic similarity searches
-on them, also known as vector search.
+KNN_MATCH and VECTOR_SIMILARITY functions, effectively conducting HNSW
+semantic similarity searches on them, also known as vector search.
 
 :::{rubric} About
 :::
@@ -60,6 +60,7 @@ with Lucene Vector Search using SQL.
 ```
 - [FLOAT_VECTOR](inv:crate-reference#type-float_vector)
 - [KNN_MATCH](inv:crate-reference#scalar_knn_match)
+- [VECTOR_SIMILARITY](inv:crate-reference#scalar_vector_similarity)
 
 ```{rubric} Related
 ```
@@ -121,10 +122,16 @@ VALUES
 **DQL**
 
 ```sql
-SELECT text, _score
+WITH param AS
+  (SELECT [0.3, 0.6, 0.0, 0.9] AS sv)
+SELECT
+  text,
+  VECTOR_SIMILARITY(embedding,
+    (SELECT sv FROM param)) AS score
 FROM word_embeddings
-WHERE KNN_MATCH(embedding,[0.3, 0.6, 0.0, 0.9], 2)
-ORDER BY _score DESC;
+WHERE KNN_MATCH(
+  embedding, (SELECT sv FROM param), 2)
+ORDER BY score DESC;
 ```
 :::
 
@@ -134,7 +141,7 @@ ORDER BY _score DESC;
 
 ```text
 +----------------------+-----------+
-| text                 |    _score |
+| text                 |     score |
 +----------------------+-----------+
 | Discovering galaxies | 0.9174312 |
 | Exploring the cosmos | 0.9090909 |
@@ -212,7 +219,8 @@ of an example exercising a RAG workflow.
 
 It uses the white-paper [Time series data in manufacturing] as input data,
 generates embeddings using OpenAI's ChatGPT, stores them into a table
-using `FLOAT_VECTOR(1536)`, and queries it using the `KNN_MATCH` function.
+using `FLOAT_VECTOR(1536)`, and queries it using the `KNN_MATCH` and
+`VECTOR_SIMILARITY` functions.
 
 {{ '{}[langchain-rag-sql-github]'.format(nb_github) }} {{ '{}[langchain-rag-sql-colab]'.format(nb_colab) }} {{ '{}[langchain-rag-sql-binder]'.format(nb_binder) }}
 :::

--- a/docs/feature/search/vector/index.md
+++ b/docs/feature/search/vector/index.md
@@ -91,7 +91,7 @@ distance.
 :class-row: title-slim
 
 :::{grid-item}
-:columns: auto 6 6 6
+:columns: auto 5 5 5
 **DDL**
 
 ```sql
@@ -103,7 +103,7 @@ CREATE TABLE word_embeddings (
 :::
 
 :::{grid-item}
-:columns: auto 6 6 6
+:columns: auto 7 7 7
 **DML**
 
 ```sql
@@ -118,7 +118,7 @@ VALUES
 :::
 
 :::{grid-item}
-:columns: auto 6 6 6
+:columns: auto 7 7 7
 **DQL**
 
 ```sql
@@ -126,17 +126,19 @@ WITH param AS
   (SELECT [0.3, 0.6, 0.0, 0.9] AS sv)
 SELECT
   text,
-  VECTOR_SIMILARITY(embedding,
-    (SELECT sv FROM param)) AS score
-FROM word_embeddings
-WHERE KNN_MATCH(
-  embedding, (SELECT sv FROM param), 2)
-ORDER BY score DESC;
+  VECTOR_SIMILARITY(embedding, (SELECT sv FROM param))
+    AS score
+FROM
+  word_embeddings
+WHERE
+  KNN_MATCH(embedding, (SELECT sv FROM param), 2)
+ORDER BY
+  score DESC;
 ```
 :::
 
 :::{grid-item}
-:columns: auto 6 6 6
+:columns: auto 5 5 5
 **Result**
 
 ```text


### PR DESCRIPTION
## About
We found the [canonical feature page about vector search](https://cratedb.com/docs/guide/feature/search/vector/) lacked a reference to the [VECTOR_SIMILARITY](https://cratedb.com/docs/crate/reference/en/latest/general/builtins/scalar-functions.html#scalar-vector-similarity) SQL function, that was added on a later iteration, after initially conceiving that page.

## Preview
https://cratedb-guide--144.org.readthedocs.build/feature/search/vector/

## Q&A
If you have any other material in this regard we could bring into this page, please let us know.

/cc @karynzv, @wierdvanderhaar, @hlcianfagna, @hammerhead 