### PR TITLE
Integrations: Consolidate section ingredients into flat list, and expand in-depth, part 1

### DIFF
--- a/docs/domain/ml/index.md
+++ b/docs/domain/ml/index.md
@@ -252,46 +252,15 @@ solution.
 :::
 
 
-(llamaindex)=
+(ml-llamaindex)=
 ### LlamaIndex
 
-[LlamaIndex] is a data framework for Large Language Models (LLMs). It comes with
-pre-trained models on massive public datasets such as GPT-4 or Llama 2, and
-provides an interface to external data sources allowing for natural language
-querying on your private data.
+:::{toctree}
+:maxdepth: 1
 
-Azure Open AI Service is a fully managed service that runs on the Azure global
-infrastructure and allows developers to integrate OpenAI models into their
-applications. Through Azure Open AI API one can easily access a wide range of
-AI models in a scalable and reliable way.
-
-What can you do with LlamaIndex?
-
-- [LlamaIndex: Building a RAG pipeline]
-- [LlamaIndex: Building an Agent]
-- [LlamaIndex: Using Workflows]
-
-::::{info-card}
-:::{grid-item}
-:columns: 9
-**Demo: Using LlamaIndex with OpenAI and CrateDB**
-
-- Connect your CrateDB data to an LLM using OpenAI or Azure OpenAI.
-- Query the database in human language,
-  i.e. query CrateDB in plain English.
-
-{hyper-tutorial}`[LlamaIndex and CrateDB: Tutorial]`
-[![README](https://img.shields.io/badge/Open-README-darkblue?logo=GitHub)][LlamaIndex and CrateDB: Code Examples]
-[![Program on GitHub](https://img.shields.io/badge/Open%20on-GitHub-darkgreen?logo=GitHub)][llamaindex-nlquery-github]
+../../integrate/llamaindex/index
 :::
-:::{grid-item}
-:columns: 3
-{tags-primary}`Fundamentals` \
-{tags-secondary}`LLM` \
-{tags-secondary}`NLP` \
-{tags-secondary}`RAG`
-:::
-::::
+
 
 
 ```{toctree}
@@ -310,13 +279,6 @@ tensorflow
 [How to set up LangChain with CrateDB]: https://community.cratedb.com/t/how-to-set-up-langchain-with-cratedb/1576
 [How to Use Private Data in Generative AI]: https://youtu.be/icquKckM4o0?feature=shared
 [Jupyter Notebook]: https://jupyter.org/
-[LlamaIndex]: https://www.llamaindex.ai/framework
-[LlamaIndex: Building a RAG pipeline]: https://docs.llamaindex.ai/en/stable/understanding/rag/
-[LlamaIndex: Building an Agent]: https://docs.llamaindex.ai/en/stable/understanding/agent/
-[LlamaIndex: Using Workflows]: https://docs.llamaindex.ai/en/stable/understanding/workflows/
-[LlamaIndex and CrateDB: Code Examples]: https://github.com/crate/cratedb-examples/tree/main/topic/machine-learning/llama-index
-[LlamaIndex and CrateDB: Tutorial]: https://community.cratedb.com/t/how-to-connect-your-cratedb-data-to-llm-with-llamaindex-and-azure-openai/1612
-[llamaindex-nlquery-github]: https://github.com/crate/cratedb-examples/blob/main/topic/machine-learning/llama-index/main.py
 [Machine Learning and CrateDB: An introduction]: https://cratedb.com/blog/machine-learning-and-cratedb-part-one
 [Machine Learning and CrateDB: Getting Started With Jupyter]: https://cratedb.com/blog/machine-learning-cratedb-jupyter
 [Machine Learning and CrateDB: Experiment Design & Linear Regression]: https://cratedb.com/blog/machine-learning-and-cratedb-part-three-experiment-design-and-linear-regression

--- a/docs/domain/ml/index.md
+++ b/docs/domain/ml/index.md
@@ -242,111 +242,14 @@ solution.
 ::::
 
 
-(langchain)=
+(ml-langchain)=
 ### LangChain
 
-Tutorials and Notebooks about using [LangChain] together with CrateDB.
-LangChain has a number of components designed to help build Q&A applications,
-and RAG applications more generally.
-This feature uses CrateDB's Vector Store implementation.
+:::{toctree}
+:maxdepth: 1
 
-- What can you build with LangChain?
-
-  - [LangChain: Retrieval augmented generation]
-  - [LangChain: Analyzing structured data]
-  - [LangChain: Chatbots]
-  - [LangChain: Q&A with SQL]
-
-
-::::{info-card}
-:::{grid-item}
-:columns: 9
-**Tutorial: Set up LangChain with CrateDB**
-
-LangChain is a framework for developing applications powered by language models.
-For this tutorial, we are going to use it to interact with CrateDB using only
-natural language without writing any SQL.
-
-To achieve that, you will need a CrateDB instance running, an OpenAI API key,
-and some Python knowledge.
-
-[![Navigate to Tutorial](https://img.shields.io/badge/Navigate%20to-Tutorial-darkblue?logo=Markdown)][How to set up LangChain with CrateDB]
+../../integrate/langchain/index
 :::
-:::{grid-item}
-:columns: 3
-{tags-primary}`Fundamentals` \
-{tags-secondary}`Vector Store` \
-{tags-secondary}`LLM` \
-{tags-secondary}`RAG`
-:::
-::::
-
-
-::::{info-card}
-:::{grid-item}
-:columns: 9
-**Notebook: Vector Similarity Search**
-
-CrateDB's `FLOAT_VECTOR` type and its `KNN_MATCH` function can be used
-for storing and retrieving embeddings, and for conducting similarity
-searches.
-
-[![README](https://img.shields.io/badge/Open-README-darkblue?logo=GitHub)][LangChain and CrateDB: Code Examples]
-[![Notebook on GitHub](https://img.shields.io/badge/Open%20on-GitHub-darkgreen?logo=GitHub)][langchain-similarity-github]
-[![Notebook on Colab](https://img.shields.io/badge/Open%20on-Colab-blue?logo=Google%20Colab)][langchain-similarity-colab]
-[![Notebook on Binder](https://img.shields.io/badge/Open%20on-Binder-lightblue?logo=binder)][langchain-similarity-binder]
-:::
-:::{grid-item}
-:columns: 3
-{tags-primary}`Fundamentals` \
-{tags-secondary}`Vector Store` \
-{tags-secondary}`LLM` \
-{tags-secondary}`RAG`
-:::
-::::
-
-
-::::{info-card}
-:::{grid-item}
-:columns: 9
-**Notebook: SQLAlchemy Document Loader**
-
-Database tables in CrateDB can be used as a source provider for
-LangChain documents.
-
-[![README](https://img.shields.io/badge/Open-README-darkblue?logo=GitHub)][LangChain and CrateDB: Code Examples]
-[![Notebook on GitHub](https://img.shields.io/badge/Open%20on-GitHub-darkgreen?logo=GitHub)][langchain-document-loader-github]
-[![Notebook on Colab](https://img.shields.io/badge/Open%20on-Colab-blue?logo=Google%20Colab)][langchain-document-loader-colab]
-[![Notebook on Binder](https://img.shields.io/badge/Open%20on-Binder-lightblue?logo=binder)][langchain-document-loader-binder]
-:::
-:::{grid-item}
-:columns: 3
-{tags-primary}`Fundamentals` \
-{tags-secondary}`Vector Store` \
-{tags-secondary}`Data I/O`
-:::
-::::
-
-
-::::{info-card}
-:::{grid-item}
-:columns: 9
-**Notebook: Conversational History**
-
-CrateDB supports managing LangChain's conversation history.
-
-[![README](https://img.shields.io/badge/Open-README-darkblue?logo=GitHub)][LangChain and CrateDB: Code Examples]
-[![Notebook on GitHub](https://img.shields.io/badge/Open%20on-GitHub-darkgreen?logo=GitHub)][langchain-conversational-history-github]
-[![Notebook on Colab](https://img.shields.io/badge/Open%20on-Colab-blue?logo=Google%20Colab)][langchain-conversational-history-colab]
-[![Notebook on Binder](https://img.shields.io/badge/Open%20on-Binder-lightblue?logo=binder)][langchain-conversational-history-binder]
-:::
-:::{grid-item}
-:columns: 3
-{tags-primary}`Fundamentals` \
-{tags-secondary}`Vector Store` \
-{tags-secondary}`History`
-:::
-::::
 
 
 (llamaindex)=
@@ -407,17 +310,6 @@ tensorflow
 [How to set up LangChain with CrateDB]: https://community.cratedb.com/t/how-to-set-up-langchain-with-cratedb/1576
 [How to Use Private Data in Generative AI]: https://youtu.be/icquKckM4o0?feature=shared
 [Jupyter Notebook]: https://jupyter.org/
-[LangChain]: https://python.langchain.com/
-[LangChain: Analyzing structured data]: https://python.langchain.com/docs/how_to/#extraction
-[LangChain: Chatbots]: https://python.langchain.com/docs/how_to/#chatbots
-[LangChain: Q&A with SQL]: https://python.langchain.com/docs/how_to/#qa-over-sql--csv
-[LangChain: Retrieval augmented generation]: https://python.langchain.com/docs/tutorials/sql_qa/
-[langchain-conversational-history-binder]: https://mybinder.org/v2/gh/crate/cratedb-examples/main?labpath=topic%2Fmachine-learning%2Fllm-langchain%2Fconversational_memory.ipynb
-[langchain-conversational-history-colab]: https://colab.research.google.com/github/crate/cratedb-examples/blob/main/topic/machine-learning/llm-langchain/conversational_memory.ipynb
-[langchain-conversational-history-github]: https://github.com/crate/cratedb-examples/blob/main/topic/machine-learning/llm-langchain/conversational_memory.ipynb
-[langchain-document-loader-binder]: https://mybinder.org/v2/gh/crate/cratedb-examples/main?labpath=topic%2Fmachine-learning%2Fllm-langchain%2Fdocument_loader.ipynb
-[langchain-document-loader-colab]: https://colab.research.google.com/github/crate/cratedb-examples/blob/main/topic/machine-learning/llm-langchain/document_loader.ipynb
-[langchain-document-loader-github]: https://github.com/crate/cratedb-examples/blob/main/topic/machine-learning/llm-langchain/document_loader.ipynb
 [LlamaIndex]: https://www.llamaindex.ai/framework
 [LlamaIndex: Building a RAG pipeline]: https://docs.llamaindex.ai/en/stable/understanding/rag/
 [LlamaIndex: Building an Agent]: https://docs.llamaindex.ai/en/stable/understanding/agent/

--- a/docs/integrate/apache-flink/index.md
+++ b/docs/integrate/apache-flink/index.md
@@ -1,0 +1,208 @@
+(apache-flink)=
+(flink)=
+
+# Apache Flink
+
+```{div}
+:style: "float: right"
+[![](https://flink.apache.org/flink-header-logo.svg){w=180px}](https://flink.apache.org/)
+```
+
+[Apache Flink] is a programming framework and distributed processing engine
+for stateful computations over unbounded and bounded data streams, written
+in Java. It is a battle-hardened stream processor widely used for demanding
+real-time applications.
+
+Flink has been designed to run in all common cluster environments, perform
+computations at in-memory speed and at any scale. It received the [2023 SIGMOD
+Systems Award].
+
+> Apache Flink greatly expanded the use of stream data-processing.
+> Data Pipelines Done Right.
+
+![](https://flink.apache.org/img/flink-home-graphic.png){h=200px}
+
+:::{dropdown} **Managed Flink**
+A few companies are specializing in offering managed Flink services.
+
+- [Aiven] offers their managed [Aiven for Apache Flink] solution.
+- [Immerok Cloud]'s offering is being converged into [Flink managed by Confluent],
+  see [Confluent Streaming Data Pipelines].
+:::
+
+```{div}
+:style: "clear: both"
+```
+
+
+## Connect
+Flink's [JdbcSink] is a streaming connector that writes data to a JDBC database,
+for example using the [PostgreSQL JDBC Driver] that also works with CrateDB.
+When configuring the data sink, use:
+:url:
+  `jdbc:postgresql://localhost:5432/crate`
+:driver:
+  `org.postgresql.Driver`
+
+
+## Synopsis
+```python
+from pyflink.common import Types
+from pyflink.datastream.connectors.jdbc import JdbcConnectionOptions, JdbcExecutionOptions, JdbcSink
+
+JdbcSink.sink(
+    "INSERT INTO doc.weather_flink_sink (location, current) VALUES (?, ?)",
+    Types.ROW_NAMED(["location", "current"], [Types.STRING(), Types.STRING()]),
+    JdbcConnectionOptions.JdbcConnectionOptionsBuilder()
+    .with_url("jdbc:postgresql://localhost:5432/crate")
+    .with_driver_name("org.postgresql.Driver")
+    .with_user_name("crate")
+    .with_password("")
+    .build())
+```
+:::::{dropdown} More Examples
+::::{tab-set}
+
+:::{tab-item} Java
+
+```java
+import org.apache.flink.connector.jdbc.JdbcConnectionOptions;
+import org.apache.flink.connector.jdbc.JdbcExecutionOptions;
+import org.apache.flink.connector.jdbc.JdbcSink;
+
+JdbcSink.sink(
+    "INSERT INTO my_schema.books (id, title, authors, year) VALUES (?, ?, ?, ?)",
+    (statement, book) -> {
+        statement.setLong(1, book.id);
+        statement.setString(2, book.title);
+        statement.setString(3, book.authors);
+        statement.setInt(4, book.year);
+    },
+    JdbcExecutionOptions.builder()
+        .withBatchSize(1000)
+        .withBatchIntervalMs(200)
+        .withMaxRetries(5)
+        .build(),
+    new JdbcConnectionOptions.JdbcConnectionOptionsBuilder()
+        .withUrl("jdbc:postgresql://localhost:5432/crate")
+        .withDriverName("org.postgresql.Driver")
+        .withUsername("crate")
+        .withPassword("")
+        .build()
+));
+```
+:::
+
+:::{tab-item} Python
+```python
+from pyflink.common import Types
+from pyflink.datastream.connectors.jdbc import JdbcConnectionOptions, JdbcExecutionOptions, JdbcSink
+
+JdbcSink.sink(
+    "INSERT INTO doc.weather_flink_sink (location, current) VALUES (?, ?)",
+    Types.ROW_NAMED(["location", "current"], [Types.STRING(), Types.STRING()]),
+    JdbcConnectionOptions.JdbcConnectionOptionsBuilder()
+    .with_url("jdbc:postgresql://localhost:5432/crate")
+    .with_driver_name("org.postgresql.Driver")
+    .with_user_name("crate")
+    .with_password("")
+    .build(),
+    JdbcExecutionOptions.builder()
+    .with_batch_interval_ms(1000)
+    .with_batch_size(200)
+    .with_max_retries(5)
+    .build()
+)
+```
+:::
+::::
+:::::
+
+
+## Learn
+
+:::{rubric} Tutorials
+:::
+- [Build a data ingestion pipeline using Kafka, Flink, and CrateDB]
+
+:::{rubric} Development
+:::
+- [Executable stack with Apache Kafka, Apache Flink, and CrateDB] (Java)
+- [Streaming data with Apache Kafka, Apache Flink and CrateDB] (Python)
+
+
+:::{rubric} Webinars
+:::
+
+::::{info-card}
+
+:::{grid-item}
+:columns: auto auto 8 8
+**Apache Flink 101**
+
+Why Flink is interesting for building real-time streaming applications,
+and how it works.
+
+Flink's performance and robustness are the results of a handful of core design
+principles, including a shared-nothing architecture with local state, event-time
+processing, and state snapshots (for recovery). This course introduces you to
+these core concepts.
+:::
+
+:::{grid-item}
+:columns: auto auto 4 4
+
+<iframe width="240" src="https://www.youtube-nocookie.com/embed/3cg5dABA6mo?list=PLa7VYi0yPIH1UdmQcnUr8lvjbUV8JriK0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+&nbsp;
+
+{tags-primary}`Webinar`
+{tags-secondary}`Fundamentals`
+:::
+
+::::
+
+
+::::{info-card}
+
+:::{grid-item}
+:columns: auto auto 8 8
+**CrateDB Community Day: Maximizing your data potential with CrateDB integrations**
+
+Flink connects different messaging systems, file systems, and database key/value
+stores for multiple purposes. For data integrations, it can serve as a data hub
+between systems and much more like event-driven applications, and it's very flexible. 
+
+The webinar includes a live demo of Apache Flink with CrateDB as source or sink.
+
+- [CrateDB Community Day 2nd Edition: Summary and Highlights]
+- [Community Day: Stream processing with Apache Flink and CrateDB]
+:::
+
+:::{grid-item}
+:columns: auto auto 4 4
+
+<iframe width="240" src="https://www.youtube-nocookie.com/embed/R4UxMdrR5os?t=2207" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+&nbsp;
+
+{tags-primary}`Webinar`
+{tags-secondary}`Integrations`
+:::
+
+::::
+
+
+
+[2023 SIGMOD Systems Award]: https://sigmod.org/2023-sigmod-systems-award/
+[Aiven]: https://aiven.io/
+[Aiven for Apache Flink]: https://aiven.io/flink
+[Apache Flink]: https://flink.apache.org/
+[Build a data ingestion pipeline using Kafka, Flink, and CrateDB]: https://dev.to/crate/build-a-data-ingestion-pipeline-using-kafka-flink-and-cratedb-1h5o
+[Community Day: Stream processing with Apache Flink and CrateDB]: https://cratedb.com/event/cratedb-community-day-2023
+[Confluent Streaming Data Pipelines]: https://www.confluent.io/streaming-data-pipelines/
+[CrateDB Community Day 2nd Edition: Summary and Highlights]: https://cratedb.com/blog/cratedb-community-day-2nd-edition-summary-and-highlights
+[Executable stack with Apache Kafka, Apache Flink, and CrateDB]: https://github.com/crate/cratedb-examples/tree/main/framework/flink/kafka-jdbcsink-java
+[Flink managed by Confluent]: https://www.datanami.com/2023/05/17/confluents-new-cloud-capabilities-address-data-streaming-hurdles/
+[Immerok Cloud]: https://web.archive.org/web/20230602085618/https://www.immerok.io/product
+[JdbcSink]: https://nightlies.apache.org/flink/flink-docs-release-1.20/docs/connectors/datastream/jdbc/
+[PostgreSQL JDBC Driver]: https://jdbc.postgresql.org/
+[Streaming data with Apache Kafka, Apache Flink and CrateDB]: https://github.com/crate/cratedb-examples/tree/main/framework/flink/kafka-jdbcsink-python

--- a/docs/integrate/apache-superset/index.md
+++ b/docs/integrate/apache-superset/index.md
@@ -1,0 +1,158 @@
+(apache-superset)=
+(preset)=
+(superset)=
+
+# Apache Superset / Preset
+
+```{div}
+:style: "float: right"
+[![](https://cratedb.com/hs-fs/hubfs/Apache-Superset-Logo-392x140@2x.png?width=604&height=216&name=Apache-Superset-Logo-392x140@2x.png){w=180px}](https://superset.apache.org/)
+
+[![](https://github.com/crate/crate-clients-tools/assets/453543/9d07da87-8aff-4569-bf2a-0a16bf89f4bc){w=180px}](https://preset.io/)
+```
+
+[Apache Superset] is an open-source modern data exploration and visualization
+platform, written in Python.
+
+[Preset] offers a managed, elevated, and enterprise-grade SaaS for open-source
+Apache Superset.
+
+![](https://superset.apache.org/img/hero-screenshot.jpg){h=200px}
+![](https://github.com/crate/crate-clients-tools/assets/453543/0f8f7bd8-2e30-4aca-bcf3-61fbc81da855){h=200px}
+
+:::{dropdown} **Managed Superset**
+```{div}
+:style: "float: right"
+[![](https://github.com/crate/crate-clients-tools/assets/453543/9d07da87-8aff-4569-bf2a-0a16bf89f4bc){w=180px}](https://preset.io/)
+```
+
+[Preset Cloud] is a fully-managed, open-source BI for the modern data stack,
+based on Apache Superset.
+
+- **Hassle-free setup:** There is no need to install or maintain software with Preset.
+  Get the latest version of Superset in a secure, reliable, and scalable SaaS experience.
+- **Up-to-date Superset, always:** Access all the latest features of Superset
+  released and thoroughly tested every two weeks.
+- **One-click to deploy multiple workspaces:** Give each team in your organization
+  a separate Superset workspace to protect sensitive data.
+- **Control user roles and access:** Easily assign roles and fine-tune data access
+  using RBAC and row-level security (RLS).
+
+```{div}
+:style: "clear: both"
+```
+:::
+
+
+## Install
+
+Follow the steps in [how to install database drivers in Docker Images] to install the
+[CrateDB connector package] when setting up Superset locally using Docker Compose.
+```shell
+echo "sqlalchemy-cratedb" >> ./docker/requirements-local.txt
+```
+
+
+## Connect
+
+Use a suitable SQLAlchemy connection string matching your environment.
+When connecting to [CrateDB Self-Managed] on localhost,
+for evaluation purposes, use:
+```
+crate://crate@127.0.0.1:4200
+```
+
+When connecting to [CrateDB Cloud], use:
+```
+crate://<username>:<password>@<clustername>.cratedb.net:4200/?ssl=true
+```
+
+
+## Learn
+
+:::{rubric} Tutorials
+:::
+- [Introduction to time series visualization in CrateDB and Apache Superset (Blog)]
+- [Use CrateDB and Apache Superset for Open Source Data Warehousing and Visualization (Blog)]
+- [Introduction to time series Visualization in CrateDB and Apache Superset (Preset.io)]
+
+:::{rubric} Development
+:::
+- [Set up Apache Superset with CrateDB]
+- [Set up an Apache Superset development sandbox with CrateDB]
+- [Verify Apache Superset with CrateDB]
+
+
+:::{rubric} Webinars
+:::
+
+::::{info-card}
+
+:::{grid-item}
+:columns: auto auto 8 8
+**Apache Superset 101**
+
+From connecting databases to building charts, dashboards, and interactive filters,
+this video educates about at all the basic surfaces and workflows of Apache Superset.
+:::
+
+:::{grid-item}
+:columns: auto auto 4 4
+
+<iframe width="240" src="https://www.youtube-nocookie.com/embed/mAIH3hUoxEE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+&nbsp;
+
+{tags-primary}`Webinar`
+{tags-secondary}`Fundamentals`
+:::
+
+::::
+
+
+::::{info-card}
+
+:::{grid-item}
+:columns: auto auto 8 8
+**Apache Superset and CrateDB: Introduction to Time-Series Visualization**
+
+In this webinar, we will discuss how to use different visualization options in
+Superset coupled with a SQL interface to derive interesting insights and findings
+from the time-series dataset.
+
+- [Introduction to time series visualization in CrateDB and Apache Superset (Webinar)]
+:::
+
+:::{grid-item}
+:columns: auto auto 4 4
+
+<iframe width="240" src="https://www.youtube-nocookie.com/embed/21KXInqrdeg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+&nbsp;
+
+{tags-primary}`Webinar`
+{tags-secondary}`Integrations`
+:::
+
+::::
+
+
+
+```{seealso}
+[CrateDB and Superset]
+```
+
+
+[Apache Superset]: https://superset.apache.org/
+[CrateDB and Superset]: https://cratedb.com/integrations/cratedb-and-apache-superset
+[CrateDB Cloud]: https://cratedb.com/product/cloud
+[CrateDB connector package]: https://superset.apache.org/docs/configuration/databases#cratedb
+[CrateDB Self-Managed]: https://cratedb.com/product/self-managed
+[how to install database drivers in Docker Images]: https://superset.apache.org/docs/configuration/databases#installing-drivers-in-docker-images
+[Introduction to time series visualization in CrateDB and Apache Superset (Blog)]: https://community.cratedb.com/t/introduction-to-time-series-visualization-in-cratedb-and-superset/1041
+[Introduction to time series visualization in CrateDB and Apache Superset (Webinar)]: https://cratedb.com/resources/webinars/lp-wb-introduction-to-time-series-visualization-in-cratedb-apache-superset
+[Introduction to time series Visualization in CrateDB and Apache Superset (Preset.io)]: https://preset.io/blog/timeseries-cratedb-superset/
+[Preset]: https://preset.io/
+[Preset Cloud]: https://preset.io/product/
+[Set up Apache Superset with CrateDB]: https://community.cratedb.com/t/set-up-apache-superset-with-cratedb/1716
+[Set up an Apache Superset development sandbox with CrateDB]: https://community.cratedb.com/t/set-up-an-apache-superset-development-sandbox-with-cratedb/1163
+[Use CrateDB and Apache Superset for Open Source Data Warehousing and Visualization (Blog)]: https://cratedb.com/blog/use-cratedb-and-apache-superset-for-open-source-data-warehousing-and-visualization
+[Verify Apache Superset with CrateDB]: https://github.com/crate/cratedb-examples/tree/main/application/apache-superset

--- a/docs/integrate/bi/index.md
+++ b/docs/integrate/bi/index.md
@@ -1,5 +1,6 @@
 (analysis)=
 (bi)=
+(bi-tools)=
 
 # Business Intelligence
 

--- a/docs/integrate/cdc/index.md
+++ b/docs/integrate/cdc/index.md
@@ -54,6 +54,7 @@ Kinesis Stream, and consume that from an adapter to a consolidation database.
 - See: [](#cdc-dynamodb)
 :::
 
+(debezium)=
 ## Debezium
 Debezium is an open source distributed platform for change data capture (CDC).
 It is built on top of Apache Kafka, a distributed streaming platform. It allows

--- a/docs/integrate/dbt/index.md
+++ b/docs/integrate/dbt/index.md
@@ -1,0 +1,136 @@
+(dbt)=
+
+# dbt
+
+```{div}
+:style: "float: right"
+[![](https://www.getdbt.com/ui/img/logos/dbt-logo.svg){w=180px}](https://www.getdbt.com/)
+```
+
+[dbt] is an open source tool for transforming data in data warehouses using Python and
+SQL. It is an SQL-first transformation workflow platform that lets teams quickly and
+collaboratively deploy analytics code following software engineering best practices
+like modularity, portability, CI/CD, and documentation.
+
+> dbt enables data analysts and engineers to transform their data using the same
+> practices that software engineers use to build applications.
+
+With dbt, anyone on your data team can safely contribute to production-grade data
+pipelines.
+
+The idea is that data engineers make source data available to an environment where
+dbt projects run, for example with [Debezium](#debezium) or with [Airflow](#apache-airflow).
+Afterwards, data analysts can run their dbt projects against this data to produce models
+(tables and views) that can be used with a number of [BI tools](#bi-tools).
+
+![](https://www.getdbt.com/ui/img/products/what-is-dbt-main-image.png){h=120px}
+![](https://www.getdbt.com/ui/img/products/what-is-dbt-deploy.svg){h=120px}
+![](https://www.getdbt.com/ui/img/products/what-is-dbt-eliminate-silos.svg){h=120px}
+
+:::{dropdown} **Managed dbt**
+```{div}
+:style: "float: right"
+[![](https://www.getdbt.com/ui/img/hero-dbt-cloud-features-2x5.png){w=180px}](https://www.getdbt.com/product/dbt-cloud/)
+```
+
+With [dbt Cloud], you can ditch time-consuming setup, and the struggles
+of scaling your data production. dbt Cloud is a full-suite service that is built for
+scale.
+
+- Start building data products quickly using the dbt Cloud IDE with integrated security
+  and governance controls.
+- Schedule, deploy, and monitor your data products using the scalable and reliable dbt
+  Cloud Scheduler.
+- Help your data teams discover and reuse data products using hosted docs or integrations
+  with the powerful Discovery API.
+- Extend your workflow beyond dbt Cloud with 30+ seamless integrations covering a range
+  of use cases across the Modern Data Stack, from observability and data quality to
+  visualization, reverse ETL, and much more.
+- Ship more high-quality data and scale your development like the 1000s of companies that
+  use dbt Cloud. They’ve used its convenient and collaboration-friendly interface to
+  eliminate the bottlenecks that keep growth limited.
+
+```{div}
+:style: "clear: both"
+```
+:::
+
+
+## Install
+Install the most recent version of the [dbt-cratedb2] Python package.
+```shell
+pip install --upgrade 'dbt-cratedb2'
+```
+
+
+## Connect
+**dbt Profile Configuration:** CrateDB targets should be set up using the
+following configuration in your `profiles.yml` file.
+```yaml
+company-name:
+  target: dev
+  outputs:
+    dev:
+      type: cratedb
+      host: [hostname]
+      user: [username]
+      password: [password]
+      port: [port]   # Default is 5432.
+      dbname: crate  # Fixed. Do not change.
+      schema: doc    # `doc` is the default schema.
+```
+dbt-cratedb2 is based on dbt-postgres, which uses [psycopg2] to connect to
+the database server.
+Because CrateDB is compatible with PostgreSQL, the same connectivity
+options apply like outlined on the [dbt Postgres Setup] documentation
+page.
+
+
+## Learn
+
+:::{rubric} Tutorials
+:::
+- [Using dbt with CrateDB]
+
+:::{rubric} Development
+:::
+- [dbt CrateDB examples]
+
+
+:::{rubric} Webinars
+:::
+
+::::{info-card}
+
+:::{grid-item}
+:columns: auto auto 8 8
+**Intro to Data Build Tool (dbt)**
+
+Learn how to get started using dbt (data-build-tool) by following along
+with an easy step-by-step tutorial.
+
+In this video, you will learn how to install dbt, initialize a new project
+and then publish your project to a GitHub repository.
+:::
+
+:::{grid-item}
+:columns: auto auto 4 4
+
+<iframe width="240" src="https://www.youtube-nocookie.com/embed/5rNquRnNb4E" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+&nbsp;
+
+{tags-primary}`Webinar`
+{tags-secondary}`Fundamentals`
+:::
+
+::::
+
+
+
+[dbt]: https://www.getdbt.com/
+[dbt-cratedb2]: https://pypi.org/project/dbt-cratedb2/
+[dbt Cloud]: https://www.getdbt.com/product/dbt-cloud/
+[dbt Postgres Setup]: https://docs.getdbt.com/docs/core/connect-data-platform/postgres-setup
+[Using dbt with CrateDB]: https://community.cratedb.com/t/using-dbt-with-cratedb/1566
+[dbt CrateDB examples]: https://github.com/crate/cratedb-examples/tree/main/framework/dbt/
+[psycopg2]: https://pypi.org/project/psycopg2/

--- a/docs/integrate/etl/index.md
+++ b/docs/integrate/etl/index.md
@@ -41,10 +41,11 @@ Tutorials and resources about configuring the managed variants, Astro and CrateD
 
 ## Apache Flink
 
-- [Build a data ingestion pipeline using Kafka, Flink, and CrateDB]
-- [Community Day: Stream processing with Apache Flink and CrateDB]
-- [Executable stack with Apache Kafka, Apache Flink, and CrateDB]
+:::{toctree}
+:maxdepth: 1
 
+../apache-flink/index
+:::
 
 
 ## Apache Hop
@@ -207,9 +208,7 @@ streamsets
 [Automating export of CrateDB data to S3 using Apache Airflow]: https://community.cratedb.com/t/cratedb-and-apache-airflow-automating-data-export-to-s3/901
 [Automating stock data collection and storage with CrateDB and Apache Airflow]: https://community.cratedb.com/t/automating-stock-data-collection-and-storage-with-cratedb-and-apache-airflow/990
 [Automating the import of Parquet files with Apache Airflow]: https://community.cratedb.com/t/automating-the-import-of-parquet-files-with-apache-airflow/1247
-[Build a data ingestion pipeline using Kafka, Flink, and CrateDB]: https://dev.to/crate/build-a-data-ingestion-pipeline-using-kafka-flink-and-cratedb-1h5o
 [Building a hot and cold storage data retention policy in CrateDB with Apache Airflow]: https://community.cratedb.com/t/cratedb-and-apache-airflow-building-a-hot-cold-storage-data-retention-policy/934
-[Community Day: Stream processing with Apache Flink and CrateDB]: https://cratedb.com/blog/cratedb-community-day-2nd-edition-summary-and-highlights
 [Connecting to CrateDB from Apache NiFi]: https://community.cratedb.com/t/connecting-to-cratedb-from-apache-nifi/647
 [CrateDB and Apache Airflow: Building a data ingestion pipeline]: https://community.cratedb.com/t/cratedb-and-apache-airflow-building-a-data-ingestion-pipeline/926 
 [CrateDB Apache Hop Bulk Loader transform]: https://hop.apache.org/manual/latest/pipeline/transforms/cratedb-bulkloader.html

--- a/docs/integrate/etl/index.md
+++ b/docs/integrate/etl/index.md
@@ -17,6 +17,8 @@ to use them optimally.
 Please also have a look at support for [](#cdc) solutions.
 
 
+(airflow)=
+(apache-airflow)=
 ## Apache Airflow / Astronomer
 
 A set of starter tutorials.
@@ -121,7 +123,11 @@ azure-functions
 
 ## dbt
 
-- [Using dbt with CrateDB]
+:::{toctree}
+:maxdepth: 1
+
+../dbt/index
+:::
 
 
 ## DynamoDB
@@ -216,7 +222,7 @@ streamsets
 [ETL pipeline using Apache Airflow with CrateDB (Source)]: https://github.com/astronomer/astro-cratedb-blogpost
 [ETL with Astro and CrateDB Cloud in 30min - fully up in the cloud]: https://www.astronomer.io/blog/run-etlelt-with-airflow-and-cratedb/
 [Examples about working with CrateDB and Meltano]: https://github.com/crate/cratedb-examples/tree/amo/meltano/framework/singer-meltano
-[Executable stack with Apache Kafka, Apache Flink, and CrateDB]: https://github.com/crate/cratedb-examples/tree/main/application/apache-kafka-flink
+[Executable stack with Apache Kafka, Apache Flink, and CrateDB]: https://github.com/crate/cratedb-examples/tree/main/framework/flink/kafka-jdbcsink-java
 [Implementing a data retention policy in CrateDB using Apache Airflow]: https://community.cratedb.com/t/implementing-a-data-retention-policy-in-cratedb-using-apache-airflow/913 
 [Ingesting MQTT messages into CrateDB using Node-RED]: https://community.cratedb.com/t/ingesting-mqtt-messages-into-cratedb-using-node-red/803
 [meltano-tap-cratedb]: https://github.com/crate-workbench/meltano-tap-cratedb
@@ -225,5 +231,4 @@ streamsets
 [Setting up data pipelines with CrateDB and Kestra]: https://community.cratedb.com/t/setting-up-data-pipelines-with-cratedb-and-kestra-io/1400
 [Updating stock market data automatically with CrateDB and Apache Airflow]: https://community.cratedb.com/t/updating-stock-market-data-automatically-with-cratedb-and-apache-airflow/1304
 [Using Apache Hop with CrateDB]: https://community.cratedb.com/t/using-apache-hop-with-cratedb/1754
-[Using dbt with CrateDB]: https://community.cratedb.com/t/using-dbt-with-cratedb/1566
 [Using SQL Server Integration Services with CrateDB]: https://github.com/crate/cratedb-examples/tree/main/application/microsoft-ssis

--- a/docs/integrate/langchain/index.md
+++ b/docs/integrate/langchain/index.md
@@ -1,0 +1,226 @@
+(langchain)=
+
+# LangChain
+
+:::{include} /_include/links.md
+:::
+
+```{div}
+:style: "float: right; font-size: 4em; margin-left: 0.3em"
+🦜️🔗
+```
+
+:::{rubric} About
+:::
+
+[LangChain] is a framework for developing applications powered by language models,
+written in Python, and with a strong focus on composability. As a language model
+integration framework, LangChain's use-cases largely overlap with those of language
+models in general, including document analysis and summarization, chatbots, and
+code analysis.
+
+The [LangChain adapter for CrateDB] provides support to use CrateDB as a vector store
+database, to load documents using LangChain's DocumentLoader, and also supports
+LangChain's conversational memory subsystem.
+
+:::{rubric} RAG
+:::
+LangChain supports retrieval-augmented generation (RAG), which is a technique for
+augmenting LLM knowledge with additional, often private or real-time, data, and mixing
+in "prompt engineering" as the process of structuring text that can be interpreted and
+understood by a generative AI model. A prompt is natural language text describing the
+task that an AI should perform.
+
+:::{rubric} Use case examples
+:::
+LangChain has a number of components designed to help build Q&A applications,
+and RAG applications more generally. Those are typical applications you can
+build using LLMs:
+
+  - [LangChain: Retrieval augmented generation]
+  - [LangChain: Analyzing structured data]
+  - [LangChain: Chatbots]
+  - [LangChain: Q&A with SQL]
+
+```{div}
+:style: "clear: both"
+```
+
+
+## Install
+```shell
+pip install \
+  'langchain-community @ git+https://github.com/crate-workbench/langchain.git@cratedb#subdirectory=libs/community' \
+  'sqlalchemy-cratedb>=0.40.0'
+```
+
+
+## Learn
+
+Tutorials and Notebooks about using [LangChain] together with CrateDB.
+
+:::{rubric} Tutorials
+:::
+
+::::{info-card}
+:::{grid-item}
+:columns: 9
+**Tutorial: Set up LangChain with CrateDB**
+
+LangChain is a framework for developing applications powered by language models.
+For this tutorial, we are going to use it to interact with CrateDB using only
+natural language without writing any SQL.
+
+To achieve that, you will need a CrateDB instance running, an OpenAI API key,
+and some Python knowledge.
+
+[![Navigate to Tutorial](https://img.shields.io/badge/Navigate%20to-Tutorial-darkblue?logo=Markdown)][How to set up LangChain with CrateDB]
+:::
+:::{grid-item}
+:columns: 3
+{tags-primary}`Fundamentals` \
+{tags-secondary}`Vector Store` \
+{tags-secondary}`LLM` \
+{tags-secondary}`RAG`
+:::
+::::
+
+
+::::{info-card}
+:::{grid-item}
+:columns: 9
+**Notebook: Vector Similarity Search**
+
+CrateDB's `FLOAT_VECTOR` type and its `KNN_MATCH` function can be used
+for storing and retrieving embeddings, and for conducting similarity
+searches.
+
+[![README](https://img.shields.io/badge/Open-README-darkblue?logo=GitHub)][LangChain and CrateDB: Code Examples]
+[![Notebook on GitHub](https://img.shields.io/badge/Open%20on-GitHub-darkgreen?logo=GitHub)][langchain-similarity-github]
+[![Notebook on Colab](https://img.shields.io/badge/Open%20on-Colab-blue?logo=Google%20Colab)][langchain-similarity-colab]
+[![Notebook on Binder](https://img.shields.io/badge/Open%20on-Binder-lightblue?logo=binder)][langchain-similarity-binder]
+:::
+:::{grid-item}
+:columns: 3
+{tags-primary}`Fundamentals` \
+{tags-secondary}`Vector Store` \
+{tags-secondary}`LLM` \
+{tags-secondary}`RAG`
+:::
+::::
+
+
+::::{info-card}
+:::{grid-item}
+:columns: 9
+**Notebook: SQLAlchemy Document Loader**
+
+Database tables in CrateDB can be used as a source provider for
+LangChain documents.
+
+[![README](https://img.shields.io/badge/Open-README-darkblue?logo=GitHub)][LangChain and CrateDB: Code Examples]
+[![Notebook on GitHub](https://img.shields.io/badge/Open%20on-GitHub-darkgreen?logo=GitHub)][langchain-document-loader-github]
+[![Notebook on Colab](https://img.shields.io/badge/Open%20on-Colab-blue?logo=Google%20Colab)][langchain-document-loader-colab]
+[![Notebook on Binder](https://img.shields.io/badge/Open%20on-Binder-lightblue?logo=binder)][langchain-document-loader-binder]
+:::
+:::{grid-item}
+:columns: 3
+{tags-primary}`Fundamentals` \
+{tags-secondary}`Vector Store` \
+{tags-secondary}`Data I/O`
+:::
+::::
+
+
+::::{info-card}
+:::{grid-item}
+:columns: 9
+**Notebook: Conversational History**
+
+CrateDB supports managing LangChain's conversation history.
+
+[![README](https://img.shields.io/badge/Open-README-darkblue?logo=GitHub)][LangChain and CrateDB: Code Examples]
+[![Notebook on GitHub](https://img.shields.io/badge/Open%20on-GitHub-darkgreen?logo=GitHub)][langchain-conversational-history-github]
+[![Notebook on Colab](https://img.shields.io/badge/Open%20on-Colab-blue?logo=Google%20Colab)][langchain-conversational-history-colab]
+[![Notebook on Binder](https://img.shields.io/badge/Open%20on-Binder-lightblue?logo=binder)][langchain-conversational-history-binder]
+:::
+:::{grid-item}
+:columns: 3
+{tags-primary}`Fundamentals` \
+{tags-secondary}`Vector Store` \
+{tags-secondary}`History`
+:::
+::::
+
+
+:::{rubric} Webinars
+:::
+
+::::{info-card}
+
+:::{grid-item}
+:columns: auto auto 8 8
+**LangChain Cookbook**
+
+The LangChain Cookbook is based off the [LangChain Conceptual Documentation].
+
+Its goal is to provide an introductory understanding of the components,
+use cases, and concepts of LangChain via ELI5 examples and code snippets.
+:::
+
+:::{grid-item}
+:columns: auto auto 4 4
+
+<iframe width="240" src="https://www.youtube-nocookie.com/embed/2xxziIWmaSA?list=PLqZXAkvF1bPNQER9mLmDbntNfSpzdDIU5" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+&nbsp;
+
+{tags-primary}`Webinar`
+{tags-secondary}`Fundamentals`
+:::
+
+::::
+
+::::{info-card}
+
+:::{grid-item}
+:columns: auto auto 8 8
+**How to Use Private Data in Generative AI**
+
+In this video recorded at FOSDEM 2024, we explain how to leverage private data
+in generative AI on behalf of an end-to-end Retrieval Augmented Generation (RAG)
+solution.
+
+- [How to Use Private Data in Generative AI] (Video)
+- [End-to-End RAG with CrateDB and LangChain] (Slides)
+:::
+
+:::{grid-item}
+:columns: auto auto 4 4
+
+<iframe width="240" src="https://www.youtube-nocookie.com/embed/icquKckM4o0?si=J0w5yG56Ld4fIXfm" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+&nbsp;
+
+{tags-primary}`Webinar`
+{tags-secondary}`Integrations`
+:::
+
+::::
+
+
+
+[End-to-End RAG with CrateDB and LangChain]: https://speakerdeck.com/cratedb/how-to-use-private-data-in-generative-ai-end-to-end-solution-for-rag-with-cratedb-and-langchain
+[How to set up LangChain with CrateDB]: https://community.cratedb.com/t/how-to-set-up-langchain-with-cratedb/1576
+[How to Use Private Data in Generative AI]: https://youtu.be/icquKckM4o0?feature=shared
+[LangChain]: https://python.langchain.com/
+[LangChain: Analyzing structured data]: https://python.langchain.com/docs/how_to/#extraction
+[LangChain: Chatbots]: https://python.langchain.com/docs/how_to/#chatbots
+[LangChain: Q&A with SQL]: https://python.langchain.com/docs/how_to/#qa-over-sql--csv
+[LangChain: Retrieval augmented generation]: https://python.langchain.com/docs/tutorials/sql_qa/
+[LangChain adapter for CrateDB]: https://github.com/crate-workbench/langchain
+[LangChain Conceptual Documentation]: https://python.langchain.com/docs/introduction/
+[langchain-conversational-history-binder]: https://mybinder.org/v2/gh/crate/cratedb-examples/main?labpath=topic%2Fmachine-learning%2Fllm-langchain%2Fconversational_memory.ipynb
+[langchain-conversational-history-colab]: https://colab.research.google.com/github/crate/cratedb-examples/blob/main/topic/machine-learning/llm-langchain/conversational_memory.ipynb
+[langchain-conversational-history-github]: https://github.com/crate/cratedb-examples/blob/main/topic/machine-learning/llm-langchain/conversational_memory.ipynb
+[langchain-document-loader-binder]: https://mybinder.org/v2/gh/crate/cratedb-examples/main?labpath=topic%2Fmachine-learning%2Fllm-langchain%2Fdocument_loader.ipynb
+[langchain-document-loader-colab]: https://colab.research.google.com/github/crate/cratedb-examples/blob/main/topic/machine-learning/llm-langchain/document_loader.ipynb
+[langchain-document-loader-github]: https://github.com/crate/cratedb-examples/blob/main/topic/machine-learning/llm-langchain/document_loader.ipynb

--- a/docs/integrate/llamaindex/index.md
+++ b/docs/integrate/llamaindex/index.md
@@ -1,0 +1,111 @@
+(llamaindex)=
+# LlamaIndex
+
+:::{include} /_include/links.md
+:::
+
+:::{rubric} About
+:::
+[LlamaIndex] is a data framework for Large Language Models (LLMs). It comes with
+pre-trained models on massive public datasets such as GPT-4 or Llama 2, and
+provides an interface to external data sources allowing for natural language
+querying on your private data.
+
+Azure Open AI Service is a fully managed service that runs on the Azure global
+infrastructure and allows developers to integrate OpenAI models into their
+applications. Through Azure Open AI API one can easily access a wide range of
+AI models in a scalable and reliable way.
+
+:::{rubric} Use case examples
+:::
+What can you do with LlamaIndex?
+
+- [LlamaIndex: Building a RAG pipeline]
+- [LlamaIndex: Building an Agent]
+- [LlamaIndex: Using Workflows]
+
+
+## Install
+Project dependencies. For example, use them in a `requirements.txt` file.
+```shell
+langchain-openai<0.3
+llama-index-embeddings-langchain<0.4
+llama-index-embeddings-openai<0.4
+llama-index-llms-azure-openai<0.4
+llama-index-llms-openai<0.4
+sqlalchemy-cratedb
+```
+
+## Synopsis
+
+:::{dropdown} Code example using the LlamaIndex package
+```python
+import os
+import sqlalchemy as sa
+
+from llama_index.core.utilities.sql_wrapper import SQLDatabase
+from llama_index.core.query_engine import NLSQLTableQueryEngine
+from llama_index.core import Settings
+
+engine = sa.create_engine("crate://localhost:4200/")
+engine.connect()
+
+sql_database = SQLDatabase(
+    engine, 
+    include_tables=["testdrive"]
+)
+
+query_engine = NLSQLTableQueryEngine(
+    sql_database=sql_database,
+    tables=[os.getenv("CRATEDB_TABLE_NAME")],
+    llm=Settings.llm
+)
+
+query_str = "What is the average value for sensor 1?"
+answer = query_engine.query(query_str)
+print(answer.get_formatted_sources())
+print("Query was:", query_str)
+print("Answer was:", answer)
+
+# query was: What is the average value for sensor 1?
+# answer was: The average value for sensor 1 is 17.03.
+```
+:::
+
+
+## Learn
+
+:::{rubric} Tutorials
+:::
+
+::::{info-card}
+:::{grid-item}
+:columns: 9
+**Demo: Using LlamaIndex with OpenAI and CrateDB**
+
+- Connect your CrateDB data to an LLM using OpenAI or Azure OpenAI.
+- Query the database in human language,
+  i.e. query CrateDB in plain English.
+
+{hyper-tutorial}`[LlamaIndex and CrateDB: Tutorial]`
+[![README](https://img.shields.io/badge/Open-README-darkblue?logo=GitHub)][LlamaIndex and CrateDB: Code Examples]
+[![Program on GitHub](https://img.shields.io/badge/Open%20on-GitHub-darkgreen?logo=GitHub)][llamaindex-nlquery-github]
+:::
+:::{grid-item}
+:columns: 3
+{tags-primary}`Fundamentals` \
+{tags-secondary}`LLM` \
+{tags-secondary}`NLP` \
+{tags-secondary}`RAG`
+:::
+::::
+
+
+
+[LlamaIndex]: https://www.llamaindex.ai/framework
+[LlamaIndex: Building a RAG pipeline]: https://docs.llamaindex.ai/en/stable/understanding/rag/
+[LlamaIndex: Building an Agent]: https://docs.llamaindex.ai/en/stable/understanding/agent/
+[LlamaIndex: Using Workflows]: https://docs.llamaindex.ai/en/stable/understanding/workflows/
+[LlamaIndex and CrateDB: Code Examples]: https://github.com/crate/cratedb-examples/tree/main/topic/machine-learning/llama-index
+[LlamaIndex and CrateDB: Tutorial]: https://community.cratedb.com/t/how-to-connect-your-cratedb-data-to-llm-with-llamaindex-and-azure-openai/1612
+[llamaindex-nlquery-github]: https://github.com/crate/cratedb-examples/blob/main/topic/machine-learning/llama-index/main.py

--- a/docs/integrate/visualize/index.md
+++ b/docs/integrate/visualize/index.md
@@ -7,18 +7,12 @@ Guidelines about data analysis and visualization with CrateDB.
 :::{include} /_include/links.md
 :::
 
-## Apache Superset / Preset
 
-**Product**
-- [Introduction to time series visualization in CrateDB and Apache Superset (Blog)]
-- [Use CrateDB and Apache Superset for Open Source Data Warehousing and Visualization (Blog)]
-- [Introduction to time series visualization in CrateDB and Apache Superset (Webinar)]
-- [Introduction to time series Visualization in CrateDB and Apache Superset (Preset.io)]
+:::{toctree}
+:maxdepth: 1
 
-**Development**
-- [Set up Apache Superset with CrateDB]
-- [Set up an Apache Superset development sandbox with CrateDB]
-- [Verify Apache Superset with CrateDB]
+../apache-superset/index
+:::
 
 
 ## Cluvio
@@ -86,14 +80,7 @@ metabase
 [Data Analysis with Cluvio and CrateDB]: https://community.cratedb.com/t/data-analysis-with-cluvio-and-cratedb/1571
 [From data storage to data analysis\: Tutorial on CrateDB and pandas]: https://community.cratedb.com/t/from-data-storage-to-data-analysis-tutorial-on-cratedb-and-pandas/1440
 [Introduction to Time Series Visualization in CrateDB and Explo]: https://cratedb.com/blog/introduction-to-time-series-visualization-in-cratedb-and-explo
-[Introduction to time series visualization in CrateDB and Apache Superset (Blog)]: https://community.cratedb.com/t/introduction-to-time-series-visualization-in-cratedb-and-superset/1041
-[Introduction to time series visualization in CrateDB and Apache Superset (Webinar)]: https://cratedb.com/resources/webinars/lp-wb-introduction-to-time-series-visualization-in-cratedb-apache-superset
-[Introduction to time series Visualization in CrateDB and Apache Superset (Preset.io)]: https://preset.io/blog/timeseries-cratedb-superset/
 [Real-time data analytics with Metabase and CrateDB]: https://www.metabase.com/community_posts/real-time-data-analytics-with-metabase-and-cratedb
-[Set up Apache Superset with CrateDB]: https://community.cratedb.com/t/set-up-apache-superset-with-cratedb/1716
-[Set up an Apache Superset development sandbox with CrateDB]: https://community.cratedb.com/t/set-up-an-apache-superset-development-sandbox-with-cratedb/1163
 [Time Series with CrateDB]: https://github.com/crate/cratedb-examples/tree/main/topic/timeseries/explore
-[Use CrateDB and Apache Superset for Open Source Data Warehousing and Visualization (Blog)]: https://cratedb.com/blog/use-cratedb-and-apache-superset-for-open-source-data-warehousing-and-visualization
 [Using Grafana with CrateDB Cloud]: #integrations-grafana
 [Using Metabase with CrateDB Cloud]: #integrations-metabase
-[Verify Apache Superset with CrateDB]: https://github.com/crate/cratedb-examples/tree/main/application/apache-superset


### PR DESCRIPTION
## About
Introduce canonical pages for integrations with CrateDB, by pulling in content from the [Ecosystem Catalog](https://cratedb.com/docs/crate/clients-tools/), and extending it with educational resources (tutorials, webinars, hands-on instructions, and code / configuration snippets).

## Preview
- [Apache Flink](https://cratedb-guide--145.org.readthedocs.build/integrate/apache-flink/)
- [Apache Superset](https://cratedb-guide--145.org.readthedocs.build/integrate/apache-superset/)
- [dbt](https://cratedb-guide--145.org.readthedocs.build/integrate/dbt/)
- [LangChain](https://cratedb-guide--145.org.readthedocs.build/integrate/langchain/)
- [LlamaIndex](https://cratedb-guide--145.org.readthedocs.build/integrate/llamaindex/)

## References
- https://github.com/crate/crate-clients-tools/pull/154