### PR TITLE
Theme: Update to crate-docs-theme>=0.37.1.dev0, introducing dark mode

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-crate-docs-theme>=0.35.0
+crate-docs-theme>=0.37.1.dev0
 
 # cache-buster-20240305
 # Remark: Used for PyPI download cache busting on GHA.


### PR DESCRIPTION
## About
Use the new theme that introduces dark mode. Thanks, @msbt.
crate-docs-theme 0.37.1.dev0 has been released, including a fix for dark mode.

## Preview
https://cratedb-guide--146.org.readthedocs.build/

## References
- https://github.com/crate/crate-docs-theme/pull/546
- https://github.com/crate/crate-docs-theme/pull/554
