### PR TITLE
Scale: Refurbish section, and absorb relevant tutorials from community forum

### DIFF
--- a/docs/admin/clustering/index.rst
+++ b/docs/admin/clustering/index.rst
@@ -14,6 +14,6 @@ adding more nodes. This section of the documentation covers that topic.
 
    multi-node-setup
    multi-zone-setup
-   scale-up-down
-   kubernetes
+   scale/index
+   scale/kubernetes
    logical-replication-setup

--- a/docs/admin/clustering/index.rst
+++ b/docs/admin/clustering/index.rst
@@ -12,8 +12,7 @@ adding more nodes. This section of the documentation covers that topic.
 .. toctree::
    :maxdepth: 1
 
-   multi-node-setup
-   multi-zone-setup
-   scale/index
-   scale/kubernetes
-   logical-replication-setup
+   Multi-Node Setup <multi-node-setup>
+   Multi-Zone Setup <multi-zone-setup>
+   Scale Clusters <scale/index>
+   Logical Replication <logical-replication-setup>

--- a/docs/admin/clustering/scale/auto.md
+++ b/docs/admin/clustering/scale/auto.md
@@ -1,0 +1,8 @@
+(scale-auto)=
+
+# Autoscale a CrateDB Cloud Cluster
+
+CrateDB’s fully managed solution CrateDB Cloud comes with a REST API,
+which enables you to automate a lot of tasks. The tutorial demonstrates
+how to use the REST API to scale your CrateDB Cloud Cluster based on a
+threshold on the number of shards in a cluster.

--- a/docs/admin/clustering/scale/auto.md
+++ b/docs/admin/clustering/scale/auto.md
@@ -153,21 +153,21 @@ In this example, I created a 3-node CrateDB Cloud cluster and created this table
 
 ``` sql
 CREATE TABLE ta (
-    "keyword" TEXT INDEX using fulltext
-    ,"ts" TIMESTAMP
-    ,"day" TIMESTAMP GENERATED ALWAYS AS date_trunc('day', ts)
-    )
+    "keyword" TEXT INDEX using fulltext,
+    "ts" TIMESTAMP,
+    "day" TIMESTAMP GENERATED ALWAYS AS date_trunc('day', ts)
+)
 CLUSTERED INTO 24 SHARDS;
 ```
 
 This will create 8 primary shards per node plus 8 replicas. This can be checked by looking at the number of shards. This can be done for example using the console by running this:
 
 ```sql
-select node ['name'], count(*)
-from sys.shards
-group by node ['name']
-order by 1
-limit 100;
+SELECT node ['name'], count(*)
+FROM sys.shards
+GROUP BY node ['name']
+ORDER BY 1
+LIMIT 100;
 ```
 
 In this example, the amount of shards is 16 per node.
@@ -185,10 +185,10 @@ To trigger the scale-out you can add a table. For example:
 
 ```sql
 CREATE TABLE tb (
-    "keyword" TEXT INDEX using fulltext
-    ,"ts" TIMESTAMP
-    ,"day" TIMESTAMP GENERATED ALWAYS AS date_trunc('day', ts)
-    )
+    "keyword" TEXT INDEX using fulltext,
+    "ts" TIMESTAMP,
+    "day" TIMESTAMP GENERATED ALWAYS AS date_trunc('day', ts)
+)
 CLUSTERED INTO 18 SHARDS;
 ```
 

--- a/docs/admin/clustering/scale/auto.md
+++ b/docs/admin/clustering/scale/auto.md
@@ -2,7 +2,226 @@
 
 # Autoscale a CrateDB Cloud Cluster
 
-CrateDB’s fully managed solution CrateDB Cloud comes with a REST API,
+_How to scale your CrateDB Cloud cluster using the REST API._
+
+CrateDB’s fully managed solution [CrateDB Cloud] comes with a REST API,
 which enables you to automate a lot of tasks. The tutorial demonstrates
 how to use the REST API to scale your CrateDB Cloud Cluster based on a
 threshold on the number of shards in a cluster.
+
+> Goal: The goal of the demo is to show how easy it is to scale out a
+> CrateDB Cloud Cluster, using a simple Python script.
+
+## Introduction
+One of the unique features of CrateDB is that it is a multi-model distributed SQL database with a shared-nothing architecture. This makes it the perfect database for those environments where scalability is needed.
+
+CrateDB's fully managed solution comes with a REST API which enables you to automate a lot of tasks. As CrateDB is world famous for its, highly scalable architecture, one of those tasks could be to scale a cluster out (horizontally) when needed, during a peak, for example, and back when possible to reduce costs.
+
+![CrateDB-Scaling-Process|690x389](https://global.discourse-cdn.com/flex020/uploads/crate/original/2X/a/a10f95850f05a064ce022b4ccca45131c1c481cd.png){w=690px align=center}
+
+This small blog shows how you can use the API to scale out and scale back a cluster when needed.
+
+
+## Prerequisites
+* A running CrateDB Cloud Cluster. If you don't have one yet, please follow this link to get [started][]. Note: To be able to scale a cluster you need to have a dedicated-tier cluster.
+* Admin UI access to the cluster.
+* An active API Key/Secret combination. See [API-KEY][] for more info.
+  Note: These keys are cloud-dependent. So, if you have multiple clusters across different cloud vendors, you need to generate different keys.
+* You will need both the organization ID and the cluster ID to be able to execute the correct API calls.
+* A Python runtime environment.
+
+[started]: https://cratedb.com/lp-crfree
+[API-KEY]: https://cratedb.com/blog/introducing-api-tokens-for-cratedb-cloud
+
+
+## Manual Scaling
+Let's do things step by step first to give you a "feel" of what is possible.
+
+Open a terminal and execute the following:
+
+```bash
+export APIKEY='USE YOUR API_KEY'
+export APISECRET='USE YOUR API_SECRET'
+export auth_data=${APIKEY}:${APISECRET}
+```
+
+Now that the authorization is defined, we can start calling APIs. For example:
+
+```bash
+curl -s -u  $auth_data \
+https://console.cratedb.cloud/api/v2/organizations/ | jq
+```
+
+Output:
+```json
+[
+  {
+    "dc": {
+      "created": "2023-08-24T13:53:34.691000+00:00",
+      "modified": "2023-10-05T09:30:54.109000+00:00"
+    },
+    "email": "wierd@nonofyourbusiness.org",
+    "id": "xxxxx-8055-4c48-b332-d06d583c1999",
+    "name": "My Organization",
+    "notifications_enabled": true,
+    "plan_type": 3,
+    "project_count": 1,
+    "role_fqn": "org_admin"
+  }
+]
+```
+
+Or if you want to know the current amount of nodes in your cluster. Here, you need to use the organization ID that was projected in the previous API call. For the next steps to work fluently, we can populate some variables.
+
+```bash
+orgid=$(curl -s -u $auth_data https://console.cratedb.cloud/api/v2/organizations/ | jq -r '.[0].id')
+echo ${orgid}
+```
+
+If you have multiple clusters running you need to filter using that cluster_name to get the clusterid.
+
+```bash
+# Replace these values with your authentication data and the name of the cluster you want to select
+cluster_name="autoscaling-demo"
+
+# Use jq to filter the output based on the cluster name and extract its ID
+clusterid=$(curl -s -u $auth_data https://console.cratedb.cloud/api/v2/clusters/ | jq -r '.[] | select(.name == '\"$cluster_name\"') | .id')
+echo ${clusterid}
+```
+
+Get the number of nodes
+```bash
+numnodes=$(curl -s -u $auth_data https://console.cratedb.cloud/api/v2/clusters/${clusterid}/ | jq -r '.num_nodes')
+echo ${numnodes}
+```
+Output
+```json
+3
+```
+So, if you want to scale out, you can call the scale API. Note that the `clusterid` is needed.
+
+```bash
+curl -u $auth_data -X PUT "https://console.cratedb.cloud/api/v2/clusters/${clusterid}/scale/" -H "accept: application/json" -H "Content-Type: application/json" -d "{\"product_unit\":2}"
+```
+
+Extra info:
+```product_unit``` is the number of nodes minus 1, as 1 is considered the minimum number. In case you want to increase a 3 node cluster you need to use 3 as the value for product_unit.
+
+```bash
+jobid=$(curl -u $auth_data -X PUT "https://console.cratedb.cloud/api/v2/clusters/${clusterid}/scale/" -H "accept: application/json" -H "Content-Type: application/json" -d "{\"product_unit\":$numnodes}" | jq -r '.last_async_operation.id')
+```
+The job can be used to query the operations API to get the info on the status.
+
+```bash
+# check status:
+curl -s -u $auth_data https://console.cratedb.cloud/api/v2/clusters/${clusterid}/operations/ | jq --arg jobid "$jobid" '.operations[] | select(.id == $jobid)'
+```
+The `status` should change from `IN_PROGRESS` to `SUCCEEDED`:
+```json
+{
+  "dc": {
+    "created": "2024-02-23T13:04:22.960000+00:00",
+    "modified": "2024-02-23T13:06:52.157000+00:00"
+  },
+  "entity": "CLUSTER",
+  "entity_id": "xxxxx-b44e-446f-adca-a092fd1df0aa",
+  "feedback_data": {
+    "message": "Successfully scaled cluster to 4 nodes."
+  },
+  "id": "xxxxx-3d33-4c4a-8c9c-93202931ed1c",
+  "non_sensitive_data": {
+    "current_num_nodes": 3,
+    "current_product_unit": 2,
+    "target_num_nodes": 4,
+    "target_product_unit": 3
+  },
+  "status": "SUCCEEDED",
+  "type": "SCALE"
+}
+```
+
+
+## Automatic Scaling
+
+We created a Python script that can be used as a starting point to enable autoscaling (out and back). In this script, we check the number of shards in a cluster, and when this crosses a threshold, the cluster will be scaled out. When the threshold goes a certain number, the cluster will be scaled back.
+
+Download the [autoscaling script from GitHub] and run it as indicated in the README.
+
+You can control the autoscale behavior by defining the ``MAX_NUM_SHARDS`` and by tweaking the number of shards in the cluster. For example, by creating an extra table with x number of shards to see the autoscale in action. In the script, the ``MAX_NUM_SHARDS`` is set to 30, but this can be changed to a number of your liking. It is also good to understand that the script will trigger a scale-out when the number of shards is higher than 80% of the ``MAX_NUM_SHARDS``. Assuming the default number of 30, this will mean that when the number of shards exceeds 24, the autoscale will kick in.
+
+In this example, I created a 3-node CrateDB Cloud cluster and created this table:
+
+``` sql
+CREATE TABLE ta (
+    "keyword" TEXT INDEX using fulltext
+    ,"ts" TIMESTAMP
+    ,"day" TIMESTAMP GENERATED ALWAYS AS date_trunc('day', ts)
+    )
+CLUSTERED INTO 24 SHARDS;
+```
+
+This will create 8 primary shards per node plus 8 replicas. This can be checked by looking at the number of shards. This can be done for example using the console by running this:
+
+```sql
+select node ['name'], count(*)
+from sys.shards
+group by node ['name']
+order by 1
+limit 100;
+```
+
+In this example, the amount of shards is 16 per node.
+
+```
+node['name']	    count(*)
+data-hot-0	        16
+data-hot-1	        16
+data-hot-2	        16
+```
+
+Run the Python script, assuming you filled in the ```API_KEY``` ```API_SECRET``` ```organization_id``` and ```cluster_id```.
+
+To trigger the scale-out you can add a table. For example:
+
+```sql
+CREATE TABLE tb (
+    "keyword" TEXT INDEX using fulltext
+    ,"ts" TIMESTAMP
+    ,"day" TIMESTAMP GENERATED ALWAYS AS date_trunc('day', ts)
+    )
+CLUSTERED INTO 18 SHARDS;
+```
+
+As you can see in the output of the running Python script this change is triggering a scale-out:
+```text
+Current avg number of shards: 16.8
+Nothing to do!
+Current avg number of shards: 28.0
+Start scaling out from 3 to 4
+Scaling in progress...................
+Scaled up successfully!
+Current avg number of shards: 21.0
+Nothing to do!
+```
+
+The scaling of a cluster takes time depending on the amount of data that needs to be rebalanced. In this example, we don't really have any data, so that will be pretty quick (+/- 3mins).
+
+When you delete the tb table, you will see that the autoscale script will scale the cluster back to 3 nodes.
+```text
+Current avg number of shards: 21.0
+Nothing to do!
+Current avg number of shards: 12.0
+Start scaling down from 4 to 3
+Scaling in progress...................
+Scaled down successfully!
+Current avg number of shards: 16.0
+```
+
+
+## Conclusion
+
+With this simple example, I showed how easy it is to scale out a CrateDB cluster either through manual or automated API calls.
+
+
+[autoscaling script from GitHub]: https://github.com/crate/cratedb-examples/tree/main/topic/autoscaling
+[CrateDB Cloud]: https://cratedb.com/product/cloud

--- a/docs/admin/clustering/scale/demand.md
+++ b/docs/admin/clustering/scale/demand.md
@@ -7,4 +7,182 @@ and how it is applied in a real-world data management scenario, specifically
 about tuning your database cluster to cope with high-demand situations.
 
 
+## Introduction
+
+Many organizations size their database infrastructure to handle the maximum level of load they can anticipate, but very often load is seasonal, in some cases around specific events on certain days of the year. Compromises are often made where infrastructure sits idle most of the year and performance is not as good as desired when requests peak.
+
+CrateDB allows clusters to be scaled both up and down by adding and removing nodes, this allows significant savings during quiet periods, and also the provisioning of extra capacity during particular periods of high activity to have optimal performance.
+
+When nodes are added or removed CrateDB automatically rebalances shards, but in cases where we have very large volumes of historical data and new nodes are only added for a short period of time, we may want to avoid any of the historical data being relocated to the temporary nodes.
+
+## About
+The approach described below explains how to achieve this using [shard allocation filtering](https://crate.io/docs/crate/reference/en/5.1/general/ddl/shard-allocation.html) on a table that is partitioned by day, the idea is that the period of high activity can be foreseen, so the scaling up will take place the day before a big event, and the scaling down someday after the event has ended.
+
+This same approach can be applied to multiple tables. It is particularly relevant for the larger tables, and smaller tables can be kept on the baseline nodes, but it is always good to consider the impact on querying performance if the small tables will be queried during the big event `JOIN`ed to the big tables that will have data on the temporary nodes.
+
+## Preparing the test environment
+
+In this example, we will imagine that the surge in demand we are preparing for is related to the 2022 FIFA Men’s World Cup running from 20/11/2022 to 18/12/2022.
+
+We will start with a 3 nodes cluster, on which we will create a test table and populate it with some pre-World Cup data:
+
+```sql
+CREATE TABLE test (
+  ts TIMESTAMP,
+  recorddetails TEXT,
+  "day" GENERATED ALWAYS AS date_trunc('day',ts)
+  )
+PARTITIONED BY ("day")
+CLUSTERED  INTO 4 SHARDS
+WITH (number_of_replicas=1);
+
+INSERT INTO test (ts) VALUES ('2022-11-18'),('2022-11-19');
+```
+
+The shards will initially look like this:
+![image|690x167](https://global.discourse-cdn.com/flex020/uploads/crate/original/1X/ac18a9cb507201d8e54771e320501f4aaac0eb16.png)
+
+## Before deploying extra nodes
+
+We want to make sure that the addition of the temporary nodes does not result on data from the large tables getting rebalanced to use these nodes.
+
+We will be able to identify the new nodes by using a custom attribute (`node.attr.storage=temporarynodes`) (see further down for details on how to configure this), so the first step is to configure the existing partitions so that they do not consider the new nodes as suitable targets for shard allocation.
+
+In CrateDB 5.1.2 or higher we can achieve this with:
+
+```sql
+/* this applies the setting to all existing partitions and new partitions */
+ALTER TABLE test SET ("routing.allocation.exclude.storage" = 'temporarynodes');
+
+/* then we run this other command so that the setting does not apply to new partitions */
+ALTER TABLE ONLY test RESET ("routing.allocation.exclude.storage");
+```
+
+No data gets reallocated when running this, and there is no impact on querying or ingestion.
+
+Starting in CrateDB 5.2 this setting is visible in `settings['routing']` in `information_schema.table_partitions`.
+
+## Deploying the extra nodes
+
+We want to deploy the new nodes setting a custom attribute.
+If using containers add a line to `args` in your YAML file with:
+
+```
+- -Cnode.attr.storage=temporarynodes
+```
+
+Otherwise add this to `crate.yml` (typically on `/etc/crate`)
+
+```
+node.attr.storage=temporarynodes
+```
+
+Please note the word `storage` in this context does not have any special meaning for CrateDB, it is just a name that we have chosen in this case for the custom attribute.
+
+Starting with CrateDB 5.2 these node attributes will be visible in `sys.nodes`.
+
+We need to calculate how many shards will be created each day (that is on each partition) during the special event, since our test table is `CLUSTERED INTO 4 SHARDS` `WITH (number_of_replicas=1)` we would have 4 (shards per partition) x 2 (primary + copy) = 8
+
+We then need to see what is the ceiling of the number we got (8) divided by the total number of nodes (baseline + temporary), if that is for instance 3+2=5 then we have ceiling(8/5)=2.
+
+That means that if a maximum of 2 of the new shards created each day during the event goes to each node then the new data will be balanced across all nodes.
+
+With the nodes ready, on the day before the event, we need to configure the special tables so that any new partitions follow this rule:
+
+```sql
+ALTER TABLE ONLY test SET ("routing.allocation.total_shards_per_node" = 2);
+```
+
+This setting (`total_shards_per_node`) is visible at partition level in `settings['routing']` in `information_schema.table_partitions`.
+
+No data gets reallocated when running this and there is no impact on querying or ingestion.
+
+This setting can be checked by using:
+
+```sql
+SHOW CREATE TABLE test;
+```
+
+## During the event
+
+Let’s now simulate the arrival of data during the event:
+
+```sql
+INSERT INTO test (ts) VALUES 
+('2022-11-20'),('2022-11-21'),('2022-11-22'),('2022-11-23'),
+('2022-11-24'),('2022-11-25'),('2022-11-26'),('2022-11-27'),
+('2022-11-28'),('2022-11-29'),('2022-11-30'),('2022-12-01'),
+('2022-12-02'),('2022-12-03'),('2022-12-04'),('2022-12-05'),
+('2022-12-06'),('2022-12-07'),('2022-12-08'),('2022-12-09'),
+('2022-12-10'),('2022-12-11'),('2022-12-12'),('2022-12-13'),
+('2022-12-14'),('2022-12-15'),('2022-12-16'),('2022-12-17'),
+('2022-12-18')
+```
+
+We can see that data from before the event stays on the baseline nodes while data for the days of the event gets distributed over all nodes:
+
+![image|690x220](https://global.discourse-cdn.com/flex020/uploads/crate/original/1X/b1c1a1ac42ac3d0eb644529e57c4b9c49eae2e87.png)
+
+The same can be checked programmatically with this query:
+
+```sql
+SELECT   table_partitions.table_schema,
+         table_partitions.table_name,
+         table_partitions.values['day']::TIMESTAMP,
+         shards.primary,
+         shards.node['name']
+FROM sys.shards
+JOIN information_schema.table_partitions
+  ON shards.partition_ident=table_partitions.partition_ident
+ORDER BY 1,2,3,4,5;
+```
+
+## The day the event ends
+
+On the last day of the event, we need to configure the table so that the next partition goes to the baseline nodes:
+
+```sql
+ALTER TABLE ONLY test SET ("routing.allocation.exclude.storage" = 'temporarynodes');
+
+ALTER TABLE ONLY test RESET ("routing.allocation.total_shards_per_node");
+```
+
+## A day after the event has ended
+
+New data should now again go the baseline nodes only.
+
+Let’s confirm it:
+
+```sql
+INSERT INTO test (ts) VALUES ('2022-12-19'),('2022-12-20')
+```
+
+![image|690x73](https://global.discourse-cdn.com/flex020/uploads/crate/original/1X/72b9f0bd28fb88402ea951f9f8a9a15c7c491ad2.png)
+
+When we are ready to decommission the temporary nodes, we need to move the data collected during the days of the event.
+
+In CrateDB 5.1.2 or higher we can achieve this with:
+
+```sql
+ALTER TABLE test SET ("routing.allocation.exclude.storage" = 'temporarynodes');
+ALTER TABLE test RESET ("routing.allocation.total_shards_per_node");
+```
+
+The data movement takes place one replica at a time and there is no impact on querying of the event’s data while it is being moved, new data also continues to flow to the baseline nodes and its ingestion and querying are also not impacted.
+
+We can monitor the progress of the data relocation querying `sys.shards` and `sys.allocations`.
+
+Once all shards have moved away from the temporary nodes, we can decommission them gracefully:
+
+```sql
+ALTER CLUSTER DECOMMISSION 'nodename';
+```
+
+Once this is done, the machines can safely be shutdown.
+
+## When the time comes for the next event
+
+If desired, new nodes can be deployed reusing the same names that were used for the temporary nodes before.
+
+
 [shard allocation filtering]: inv:crate-reference#ddl_shard_allocation

--- a/docs/admin/clustering/scale/demand.md
+++ b/docs/admin/clustering/scale/demand.md
@@ -1,0 +1,10 @@
+(scale-demand)=
+
+# Scale CrateDB clusters up and down to cope with peaks in demand
+
+This tutorial demonstrates the [shard allocation filtering] functionality,
+and how it is applied in a real-world data management scenario, specifically
+about tuning your database cluster to cope with high-demand situations.
+
+
+[shard allocation filtering]: inv:crate-reference#ddl_shard_allocation

--- a/docs/admin/clustering/scale/demand.md
+++ b/docs/admin/clustering/scale/demand.md
@@ -31,12 +31,12 @@ CREATE TABLE test (
   ts TIMESTAMP,
   recorddetails TEXT,
   "day" GENERATED ALWAYS AS date_trunc('day',ts)
-  )
+)
 PARTITIONED BY ("day")
-CLUSTERED  INTO 4 SHARDS
-WITH (number_of_replicas=1);
+CLUSTERED INTO 4 SHARDS
+WITH (number_of_replicas = 1);
 
-INSERT INTO test (ts) VALUES ('2022-11-18'),('2022-11-19');
+INSERT INTO test (ts) VALUES ('2022-11-18'), ('2022-11-19');
 ```
 
 The shards will initially look like this:
@@ -109,13 +109,13 @@ Let’s now simulate the arrival of data during the event:
 
 ```sql
 INSERT INTO test (ts) VALUES 
-('2022-11-20'),('2022-11-21'),('2022-11-22'),('2022-11-23'),
-('2022-11-24'),('2022-11-25'),('2022-11-26'),('2022-11-27'),
-('2022-11-28'),('2022-11-29'),('2022-11-30'),('2022-12-01'),
-('2022-12-02'),('2022-12-03'),('2022-12-04'),('2022-12-05'),
-('2022-12-06'),('2022-12-07'),('2022-12-08'),('2022-12-09'),
-('2022-12-10'),('2022-12-11'),('2022-12-12'),('2022-12-13'),
-('2022-12-14'),('2022-12-15'),('2022-12-16'),('2022-12-17'),
+('2022-11-20'), ('2022-11-21'), ('2022-11-22'), ('2022-11-23'),
+('2022-11-24'), ('2022-11-25'), ('2022-11-26'), ('2022-11-27'),
+('2022-11-28'), ('2022-11-29'), ('2022-11-30'), ('2022-12-01'),
+('2022-12-02'), ('2022-12-03'), ('2022-12-04'), ('2022-12-05'),
+('2022-12-06'), ('2022-12-07'), ('2022-12-08'), ('2022-12-09'),
+('2022-12-10'), ('2022-12-11'), ('2022-12-12'), ('2022-12-13'),
+('2022-12-14'), ('2022-12-15'), ('2022-12-16'), ('2022-12-17'),
 ('2022-12-18')
 ```
 
@@ -126,15 +126,15 @@ We can see that data from before the event stays on the baseline nodes while dat
 The same can be checked programmatically with this query:
 
 ```sql
-SELECT   table_partitions.table_schema,
-         table_partitions.table_name,
-         table_partitions.values['day']::TIMESTAMP,
-         shards.primary,
-         shards.node['name']
+SELECT table_partitions.table_schema,
+       table_partitions.table_name,
+       table_partitions.values['day']::TIMESTAMP,
+       shards.primary,
+       shards.node['name']
 FROM sys.shards
 JOIN information_schema.table_partitions
-  ON shards.partition_ident=table_partitions.partition_ident
-ORDER BY 1,2,3,4,5;
+  ON shards.partition_ident = table_partitions.partition_ident
+ORDER BY 1, 2, 3, 4, 5;
 ```
 
 ## The day the event ends
@@ -154,7 +154,7 @@ New data should now again go the baseline nodes only.
 Let’s confirm it:
 
 ```sql
-INSERT INTO test (ts) VALUES ('2022-12-19'),('2022-12-20')
+INSERT INTO test (ts) VALUES ('2022-12-19'), ('2022-12-20');
 ```
 
 ![image|690x73](https://global.discourse-cdn.com/flex020/uploads/crate/original/1X/72b9f0bd28fb88402ea951f9f8a9a15c7c491ad2.png)

--- a/docs/admin/clustering/scale/demand.md
+++ b/docs/admin/clustering/scale/demand.md
@@ -48,8 +48,7 @@ We want to make sure that the addition of the temporary nodes does not result on
 
 We will be able to identify the new nodes by using a custom attribute (`node.attr.storage=temporarynodes`) (see further down for details on how to configure this), so the first step is to configure the existing partitions so that they do not consider the new nodes as suitable targets for shard allocation.
 
-In CrateDB 5.1.2 or higher we can achieve this with:
-
+In CrateDB 5.1.2 or higher, you can achieve this with:
 ```sql
 /* this applies the setting to all existing partitions and new partitions */
 ALTER TABLE test SET ("routing.allocation.exclude.storage" = 'temporarynodes');
@@ -57,6 +56,14 @@ ALTER TABLE test SET ("routing.allocation.exclude.storage" = 'temporarynodes');
 /* then we run this other command so that the setting does not apply to new partitions */
 ALTER TABLE ONLY test RESET ("routing.allocation.exclude.storage");
 ```
+In CrateDB 5.9.0 or higher, you don't need to change shard allocations for each
+individual table any longer. Instead, default allocation rules can be set on
+the cluster level:
+> [CrateDB 5.9.0] added support to override `routing.allocation.*` cluster
+> settings with a `routing.allocation.*` table setting. This can be used to
+> define the default routing behavior for all tables with a cluster setting
+> and reroute individual tables by assigning the table setting using `ALTER
+> TABLE SET`.
 
 No data gets reallocated when running this, and there is no impact on querying or ingestion.
 
@@ -161,8 +168,7 @@ INSERT INTO test (ts) VALUES ('2022-12-19'), ('2022-12-20');
 
 When we are ready to decommission the temporary nodes, we need to move the data collected during the days of the event.
 
-In CrateDB 5.1.2 or higher we can achieve this with:
-
+In CrateDB 5.1.2 or higher, you can achieve this with:
 ```sql
 ALTER TABLE test SET ("routing.allocation.exclude.storage" = 'temporarynodes');
 ALTER TABLE test RESET ("routing.allocation.total_shards_per_node");
@@ -185,4 +191,5 @@ Once this is done, the machines can safely be shutdown.
 If desired, new nodes can be deployed reusing the same names that were used for the temporary nodes before.
 
 
+[CrateDB 5.9.0]: https://cratedb.com/docs/crate/reference/en/latest/appendices/release-notes/5.9.0.html
 [shard allocation filtering]: inv:crate-reference#ddl_shard_allocation

--- a/docs/admin/clustering/scale/expand.md
+++ b/docs/admin/clustering/scale/expand.md
@@ -43,7 +43,7 @@ The settings that we need are:
 * `initial_master_nodes` set to the hostname or the `node.name` of the node
 * optionally we can set a `cluster.name`
 
-If you are using containers you would pass these settings with lines in the `args` section of your YAML file, otherwise you could create `/etc/crate/crate.yml` before deploying the package for your distribution (refer to https://github.com/crate/crate/blob/master/app/src/main/dist/config/crate.yml for the template), or you could prevent the package installation from auto-starting the daemon by using a mechanism such as `policy-rcd-declarative`, then edit the configuration file (`crate.yml` ), and start the `crate` daemon once all settings are ready.
+If you are using containers you would pass these settings with lines in the `args` section of your YAML file, otherwise you could create `/etc/crate/crate.yml` before deploying the package for your distribution (refer to https://github.com/crate/crate/blob/master/app/src/main/dist/config/crate.yml for the template), or you could prevent the package installation from auto-starting the daemon by using a mechanism such as `policy-rcd-declarative`, then edit the configuration file (`crate.yml`), and start the `crate` daemon once all settings are ready.
 
 ## Networking considerations
 

--- a/docs/admin/clustering/scale/expand.md
+++ b/docs/admin/clustering/scale/expand.md
@@ -1,0 +1,4 @@
+(scale-expand)=
+
+# How to expand an existing CrateDB cluster
+

--- a/docs/admin/clustering/scale/expand.md
+++ b/docs/admin/clustering/scale/expand.md
@@ -2,3 +2,99 @@
 
 # How to expand an existing CrateDB cluster
 
+
+## Introduction
+
+A significant feature in CrateDB is that it can scale horizontally, which means that instead of adding more RAM, CPU, and disk resources to our existing nodes we can add more nodes to our CrateDB cluster.
+
+This allows the handling of volumes of data that simply could not fit on a single node, but it is also very useful in scenarios where hosting everything in a single node, or a small number of nodes, would still be possible, this is because smaller nodes are often easier to manage infrastructure-wise.
+
+More nodes also mean more resiliency to issues, on a scenario where we have for instance 5 nodes, and configure our tables with 2 replicas, we could lose 2 nodes and still serve our production workloads. This means we can carry out maintenance on the nodes one at a time and still be able to withstand an unplanned issue on another node without downtime.
+
+Today we want to review how to add a new node to an existing on-premises cluster.
+
+## Related reading
+
+- [CrateDB multi-node setup — CrateDB: How-Tos](https://crate.io/docs/crate/howtos/en/latest/clustering/multi-node-setup.html)
+
+- [Clustering — CrateDB: Reference](https://crate.io/docs/crate/reference/en/latest/concepts/clustering.html)
+
+- [Storage and consistency — CrateDB: Reference](https://crate.io/docs/crate/reference/en/latest/concepts/storage-consistency.html)
+
+## Discovery
+
+When a CrateDB node starts it needs a mechanism to get a list of the nodes that make up the cluster, this is called discovery.
+At the time of writing, there are 3 ways for a node to get this list:
+
+* The list of nodes can be defined in the `discovery.seed_hosts` setting in the configuration file (typically in `/etc/crate/crate.yml`)
+* The list can be retrieved with a DNS query, see https://crate.io/docs/crate/reference/en/5.4/config/cluster.html#discovery-via-dns
+* In AWS environments, the list of nodes can be looked up via the EC2 API, filtering on specific security groups, availability zones, and tags, see https://crate.io/docs/crate/reference/en/5.4/config/cluster.html#discovery-on-amazon-ec2
+
+For the purpose of this post, we will work with the `discovery.seed_hosts` list.
+
+## Scaling from a single-node deployment
+
+If a node is started without specifying the `initial_master_nodes` setting (the default configuration), or with `discovery_type` set to `single-node`, it will be started as a standalone instance and it cannot later be scaled into a cluster. Single-node deployments are great for development and testing, but for production setups we recommend using a cluster with at least 3 nodes.
+
+If you are going for a single-node deployment initially, but plan to scale to a multi-node cluster in the future, there are some settings to configure before the very first run of the CrateDB node so that it bootstraps as a 1-node cluster instead of a standalone instance.
+The settings that we need are:
+
+* `discovery.seed_hosts` set to the hostname or the `node.name` of the node
+* `initial_master_nodes` set to the hostname or the `node.name` of the node
+* optionally we can set a `cluster.name`
+
+If you are using containers you would pass these settings with lines in the `args` section of your YAML file, otherwise you could create `/etc/crate/crate.yml` before deploying the package for your distribution (refer to https://github.com/crate/crate/blob/master/app/src/main/dist/config/crate.yml for the template), or you could prevent the package installation from auto-starting the daemon by using a mechanism such as `policy-rcd-declarative`, then edit the configuration file (`crate.yml` ), and start the `crate` daemon once all settings are ready.
+
+## Networking considerations
+
+Nodes need to be able to resolve each other's hostnames at DNS level, and they need to be able to reach each other on a TCP port which is 4300 by default.
+
+For security reasons you should configure your network so that CrateDB cluster nodes are only reachable on port 4300 from other CrateDB nodes in the cluster.
+In a Kubernetes environment this can be achieved with a `Service` resource with a `ClusterIP`.
+In a non-containerized environment one way to do this is to use firewall software directly on each node, for instance:
+
+```bash
+#Enable ufw - all incoming connections blocked by default
+sudo ufw enable
+
+#Allow SSH if you are using it to manage your server
+sudo ufw allow 22
+
+#Allow 4200 for clients to connect to CrateDB via the http endpoint
+sudo ufw allow 4200
+
+#Allow 5432 if you have PostgreSQL clients
+sudo ufw allow 5432
+
+#Allow 4300 from 192.168.0.202 (another cluster node in this example)
+sudo ufw allow proto tcp from 192.168.0.202 to any port 4300
+```
+
+You may also want to consider network access control and/or a separate network adapter for intra-cluster communications.
+
+## Deploying the new node
+
+Make sure the new node does not auto-bootstrap as a single-node instance, you may want to either create `/etc/crate/crate.yml` in advance or use a mechanism as `policy-rcd-declarative` as mentioned earlier.
+On the configuration file for the new node:
+
+* Set `discovery.seed_hosts` to the full list of nodes, including the new one you are adding.
+* Optionally set a `node.name` , if not done the node get assigned a random name from the `sys.summits` table. You may wonder what those default names are about, they are the names of mountains in the area around our main office, we love mountains at [Crate.io](http://crate.io/).
+* Set `cluster.name` to a value that matches the other nodes in the cluster, if not specified the default cluster name is `crate`.
+* Consider if you want to set the [cluster-wide settings](https://crate.io/docs/crate/reference/en/latest/config/cluster.html#metadata-gateway) `gateway.expected_data_nodes`, `gateway.recover_after_data_nodes`, and/or `gateway.recover_after_time` to prevent the unnecessary creation of new replicas and the rebalancing of shards when a node takes a little bit longer to start, or in case of transient issues, when the cluster is starting up from a situation where all nodes are shutdown. Please note these settings are used when the cluster is starting up from being offline, if you want to delay the allocation of replicas when a node becomes unavailable on a cluster that stays online there is [a different setting at table level](https://crate.io/docs/crate/reference/en/5.4/sql/statements/create-table.html#unassigned-node-left-delayed-timeout).
+
+Now we can start the `crate` daemon, you will see the node joining the cluster and CrateDB will start using it for shards allocation.
+
+Remember to add the new nodes alongside the old ones in any monitoring system and load balancer configuration you may have in your environment.
+
+## Updating settings on the old nodes
+
+Now we need to align a number of settings in the other nodes, these are typically in the `/etc/crate/crate.yml` file:
+
+* Update `discovery.seed_hosts` adding the new node
+* If you have configured `gateway.` settings, update them to have the same values on all nodes
+
+These settings only play a role during restart, not at runtime, so you do not need to restart the nodes after making these changes, but if the `gateway.` settings need updating you may see a warning in the Admin UI which can be acknowledged.
+
+Please also note there is no need to update the `initial_master_nodes` list, this is only considered during the initial cluster bootstrapping.
+
+And that is it, we have scaled out our cluster and we are ready to work with larger volumes of data. I hope you find this useful and, as usual, please do not hesitate to raise any thoughts or questions in the [CrateDB Community](https://community.cratedb.com/).

--- a/docs/admin/clustering/scale/index.md
+++ b/docs/admin/clustering/scale/index.md
@@ -106,6 +106,36 @@ ALTER CLUSTER DECOMMISSION 'nodename';
 ```
 
 
+## Advices
+
+Please apply best-practice operation guidelines when managing your database
+cluster.
+
+:::{tip}
+:class: hero font-large
+
+For safely adding or decommissioning nodes, it is a good idea to
+add and remove only one node at a time.
+:::
+
+:::{caution}
+:class: hero font-large
+
+When restarting, shutting down, or when removing nodes from a cluster, using
+the `DECOMMISSION` command, you must be conscious about maintaining a quorum
+of nodes up and connected to the cluster as a whole, even if some nodes would
+no longer have any data.
+:::
+
+
+
+<style>
+.font-large {
+  font-size: large !important;
+}
+</style>
+
+
 [how to add new nodes to an existing cluster]: https://community.cratedb.com/t/how-to-add-new-nodes-to-an-existing-cluster/1546
 [how to scale CrateDB clusters up and down to cope with peaks in demand]: https://community.cratedb.com/t/scaling-cratedb-clusters-up-and-down-to-cope-with-peaks-in-demand/1314
 [shard allocation filtering]: inv:crate-reference#ddl_shard_allocation

--- a/docs/admin/clustering/scale/index.md
+++ b/docs/admin/clustering/scale/index.md
@@ -12,26 +12,70 @@ By running your database cluster on multiple nodes, you will gain two benefits.
   of replica nodes.
 
 
+:::{toctree}
+:maxdepth: 1
+:hidden:
+
+Expand <expand>
+On-Demand <demand>
+Autoscale <auto>
+On Kubernetes <kubernetes>
+:::
+
+
+## Learn
+
+:::::{grid}
+
+::::{grid-item-card}
+:link: scale-expand
+:link-type: ref
 (scaling-expand)=
-## Expand Cluster
+:::{rubric} Expand Cluster
+:::
+Learn how to add new nodes to an existing CrateDB database cluster
+running on your premises, in order to expand its capacity using
+horizontal scaling.
++++
+{hyper-tutorial}`scale-expand`
+::::
 
-The article about [how to add new nodes to an existing cluster] walks you
-through the process of scaling up your database cluster, and educates you
-about the corresponding details to consider.
-
-
+::::{grid-item-card}
+:link: scale-demand
+:link-type: ref
 (scaling-ondemand)=
-## Scale On-Demand
+:::{rubric} On-Demand Scaling
+:::
+Learn how to use CrateDB's [shard allocation filtering] feature in
+practice, in order to scale CrateDB clusters up and down to cope
+with peaks in high-demand situations. 
++++
+{hyper-tutorial}`scale-demand`
+::::
 
-The article about [scaling CrateDB clusters up and down to cope with peaks in
-demand] shares knowledge about the [shard allocation filtering] feature of
-CrateDB.
+::::{grid-item-card}
+:link: scale-auto
+:link-type: ref
+(scaling-autoscale)=
+:::{rubric} Automatic Scaling
+:::
+Learn how to automatically scale your CrateDB Cloud Cluster based on a
+threshold on the number of shards in a cluster, using the
+CrateDB Cloud REST API.
++++
+{hyper-tutorial}`scale-auto`
+::::
+:::::
 
-Along the lines, it demonstrates how this functionality is applied in a real-
-world data management scenario, which is about tuning your database cluster to
-cope with high-demand situations.
 
-Prepare adding extra nodes to the database cluster.
+## Synopsis
+
+A rough walkthrough how resource management works in CrateDB, to manage
+high-demand / peak situations.
+
+:::{rubric} Provision Resources
+:::
+Prepare by adding extra nodes to the database cluster.
 ```sql
 /* Apply routing setting to all existing partitions and new partitions. */
 ALTER TABLE test SET ("routing.allocation.exclude.storage" = 'temporarynodes');
@@ -40,13 +84,18 @@ ALTER TABLE test SET ("routing.allocation.exclude.storage" = 'temporarynodes');
 ALTER TABLE ONLY test RESET ("routing.allocation.exclude.storage");
 ```
 
-Before the high-demand event, properly configure table routing accordingly.
+:::{rubric} Scale Up
+:::
+Right before the high-demand event, adjust the table routing,
+so the cluster will use additional resources.
 ```sql
 ALTER TABLE ONLY test SET ("routing.allocation.total_shards_per_node" = 2);
 ```
 
-To decommission extra database nodes, we need to move the data collected during
-the days of the event.
+:::{rubric} Scale Down
+:::
+To decommission excess database nodes, move the data collected during
+the days of the event away.
 ```sql
 -- Move the collected data off the extra nodes.
 ALTER TABLE test SET ("routing.allocation.exclude.storage" = 'temporarynodes');
@@ -58,5 +107,5 @@ ALTER CLUSTER DECOMMISSION 'nodename';
 
 
 [how to add new nodes to an existing cluster]: https://community.cratedb.com/t/how-to-add-new-nodes-to-an-existing-cluster/1546
-[scaling CrateDB clusters up and down to cope with peaks in demand]: https://community.cratedb.com/t/scaling-cratedb-clusters-up-and-down-to-cope-with-peaks-in-demand/1314
+[how to scale CrateDB clusters up and down to cope with peaks in demand]: https://community.cratedb.com/t/scaling-cratedb-clusters-up-and-down-to-cope-with-peaks-in-demand/1314
 [shard allocation filtering]: inv:crate-reference#ddl_shard_allocation

--- a/docs/admin/clustering/scale/index.md
+++ b/docs/admin/clustering/scale/index.md
@@ -1,5 +1,5 @@
 (scaling-clusters)=
-# Scaling Clusters Up and Down
+# Scale Clusters Up and Down
 
 A significant feature in CrateDB is that it can scale horizontally, which means
 that instead of adding more RAM, CPU, and disk resources to existing nodes, you
@@ -21,7 +21,7 @@ about the corresponding details to consider.
 
 
 (scaling-ondemand)=
-## On-Demand Scaling
+## Scale On-Demand
 
 The article about [scaling CrateDB clusters up and down to cope with peaks in
 demand] shares knowledge about the [shard allocation filtering] feature of

--- a/docs/admin/clustering/scale/kubernetes.rst
+++ b/docs/admin/clustering/scale/kubernetes.rst
@@ -1,8 +1,8 @@
 .. _scaling-kube:
 
-=============================
-Scaling CrateDB on Kubernetes
-=============================
+===========================
+Scale CrateDB on Kubernetes
+===========================
 
 CrateDB and `Docker`_ are a great match thanks to CrateDB’s `horizontally
 scalable`_ `shared-nothing architecture`_ that lends itself well to


### PR DESCRIPTION
## About
Rework the whole section about scaling CrateDB Clusters. Feedback is very much welcome.

## Preview
**Current:** https://cratedb.com/docs/guide/admin/clustering/scale-up-down.html
**Next:** https://cratedb-guide--150.org.readthedocs.build/admin/clustering/scale/

## Details
The patch absorbs those tutorials previously published on the community forum. Thanks for your excellent work. 💯 [^1]
- https://community.cratedb.com/t/how-to-add-new-nodes-to-an-existing-cluster/1546
- https://community.cratedb.com/t/scaling-cratedb-clusters-up-and-down-to-cope-with-peaks-in-demand/1314
- https://community.cratedb.com/t/autoscale-a-cratedb-cloud-cluster/1731

## References
- https://github.com/crate/cratedb-guide/issues/148
- https://github.com/crate/infrastructure/pull/3248

[^1]: I will add a bit of polishing to them on behalf of a subsequent iteration, if you don't mind.
