### PR TITLE
Integrate: Add dedicated page about DataGrip

### DIFF
--- a/docs/_include/links.md
+++ b/docs/_include/links.md
@@ -7,6 +7,8 @@
 [cloud-datashader-github]: https://github.com/crate/cratedb-examples/blob/amo/cloud-datashader/topic/timeseries/explore/cloud-datashader.ipynb
 [CTE]: inv:crate-reference#sql_dql_with
 [CrateDB's PostgreSQL interface]: inv:crate-reference#interface-postgresql
+[crate-jdbc-standalone]: https://repo1.maven.org/maven2/io/crate/crate-jdbc-standalone/
+[crate-jdbc-standalone-latest.jar]: https://repo1.maven.org/maven2/io/crate/crate-jdbc-standalone/2.7.0/crate-jdbc-standalone-2.7.0.jar
 [dask-weather-data-colab]: https://colab.research.google.com/github/crate/cratedb-examples/blob/main/topic/timeseries/dask-weather-data-import.ipynb
 [dask-weather-data-github]: https://github.com/crate/cratedb-examples/blob/main/topic/timeseries/dask-weather-data-import.ipynb
 [Datashader]: https://datashader.org/

--- a/docs/_include/links.md
+++ b/docs/_include/links.md
@@ -6,6 +6,8 @@
 [cloud-datashader-colab]: https://colab.research.google.com/github/crate/cratedb-examples/blob/amo/cloud-datashader/topic/timeseries/explore/cloud-datashader.ipynb
 [cloud-datashader-github]: https://github.com/crate/cratedb-examples/blob/amo/cloud-datashader/topic/timeseries/explore/cloud-datashader.ipynb
 [CTE]: inv:crate-reference#sql_dql_with
+[CrateDB Cloud]: https://cratedb.com/product/cloud
+[CrateDB Self-Managed]: https://cratedb.com/product/self-managed
 [CrateDB's PostgreSQL interface]: inv:crate-reference#interface-postgresql
 [crate-jdbc-standalone]: https://repo1.maven.org/maven2/io/crate/crate-jdbc-standalone/
 [crate-jdbc-standalone-latest.jar]: https://repo1.maven.org/maven2/io/crate/crate-jdbc-standalone/2.7.0/crate-jdbc-standalone-2.7.0.jar

--- a/docs/integrate/datagrip/index.md
+++ b/docs/integrate/datagrip/index.md
@@ -97,8 +97,6 @@ any contributions and reports.
 
 [Blog: Use CrateDB With DataGrip]: https://cratedb.com/blog/use-cratedb-with-datagrip-an-advanced-database-ide
 [CrateDB and DataGrip]: https://cratedb.com/integrations/cratedb-and-datagrip
-[CrateDB Cloud]: https://cratedb.com/product/cloud
 [CrateDB JDBC Driver]: https://cratedb.com/docs/jdbc/
-[CrateDB Self-Managed]: https://cratedb.com/product/self-managed
 [DataGrip]: https://www.jetbrains.com/datagrip/
 [Tool: DataGrip]: https://github.com/crate/crate/labels/tool%3A%20DataGrip

--- a/docs/integrate/datagrip/index.md
+++ b/docs/integrate/datagrip/index.md
@@ -1,6 +1,9 @@
 (datagrip)=
 # DataGrip
 
+:::{include} /_include/links.md
+:::
+
 ```{div}
 :style: "float: right; margin-left: 0.5em"
 [![](https://blog.jetbrains.com/wp-content/uploads/2019/01/datagrip_icon.svg){w=120px}](https://www.jetbrains.com/datagrip/)
@@ -32,7 +35,7 @@ using the "Custom JARs" option when adding a database driver.
 :::
 :::{grid-item}
 [crate-jdbc-standalone] is the right choice here.
-For example, download and use the [crate-jdbc-standalone-2.7.0.jar] JAR file,
+For example, download and use the [crate-jdbc-standalone-latest.jar] JAR file,
 and select the driver class `io.crate.client.jdbc.CrateDriver`.
 :::
 :::{grid-item}
@@ -97,7 +100,5 @@ any contributions and reports.
 [CrateDB Cloud]: https://cratedb.com/product/cloud
 [CrateDB JDBC Driver]: https://cratedb.com/docs/jdbc/
 [CrateDB Self-Managed]: https://cratedb.com/product/self-managed
-[crate-jdbc-standalone]: https://repo1.maven.org/maven2/io/crate/crate-jdbc-standalone/
-[crate-jdbc-standalone-2.7.0.jar]: https://repo1.maven.org/maven2/io/crate/crate-jdbc-standalone/2.7.0/crate-jdbc-standalone-2.7.0.jar
 [DataGrip]: https://www.jetbrains.com/datagrip/
 [Tool: DataGrip]: https://github.com/crate/crate/labels/tool%3A%20DataGrip

--- a/docs/integrate/datagrip/index.md
+++ b/docs/integrate/datagrip/index.md
@@ -1,0 +1,103 @@
+(datagrip)=
+# DataGrip
+
+```{div}
+:style: "float: right; margin-left: 0.5em"
+[![](https://blog.jetbrains.com/wp-content/uploads/2019/01/datagrip_icon.svg){w=120px}](https://www.jetbrains.com/datagrip/)
+```
+
+[DataGrip] is a cross-platform database IDE that is tailored to suit the
+specific needs of professional SQL developers.
+
+It is available as a standalone application and is also included into
+other JetBrains products like IntelliJ IDEA and PyCharm.
+
+Connecting DataGrip to CrateDB uses the [CrateDB JDBC Driver].
+
+```{div}
+:style: "clear: both"
+```
+
+
+## Install
+
+::::{grid} 2
+:::{grid-item}
+For connecting to CrateDB, install the [CrateDB JDBC Driver]
+using the "Custom JARs" option when adding a database driver.
+:::
+:::{grid-item}
+![Image](https://github.com/user-attachments/assets/a8c1ada6-fd97-43f4-a1ba-91aba1520bdb){h=180px}
+![Image](https://github.com/user-attachments/assets/1f925848-fac3-4265-8bd3-96f91daf03c9){h=180px}
+:::
+:::{grid-item}
+[crate-jdbc-standalone] is the right choice here.
+For example, download and use the [crate-jdbc-standalone-2.7.0.jar] JAR file,
+and select the driver class `io.crate.client.jdbc.CrateDriver`.
+:::
+:::{grid-item}
+![Image](https://github.com/user-attachments/assets/50ccb304-5aaf-4f0b-8ae7-55445f06930c){w=400px}
+:::
+::::
+
+
+## Connect
+
+::::{grid} 2
+
+:::{grid-item}
+Now, you can add a Data Source using the CrateDB database driver.
+Please specify database URL and credentials of your CrateDB cluster.
+:::
+:::{grid-item}
+![Image](https://github.com/user-attachments/assets/147a3e8e-f1d7-413d-9e0c-1ced11333646){w=480px}
+:::
+:::{grid-item}
+For connecting to [CrateDB Self-Managed] or [CrateDB Cloud],
+use a connection URL like:
+```
+jdbc:crate://<host>:5432/
+```
+:::
+:::{grid-item}
+![Image](https://github.com/user-attachments/assets/c929aa64-f032-451c-9f9d-45e6aebb12e5){w=480px}
+:::
+
+::::
+
+
+## Usage
+After refreshing, you can browse the data tree, and use the Query Console.
+
+![Image](https://github.com/user-attachments/assets/3350a955-0a53-41d7-905b-a71cc4a767e9){h=240px}
+![Image](https://github.com/user-attachments/assets/d0a2a09d-a59f-4eda-a488-09d5ce15c08d){h=240px}
+
+
+
+## Learn
+
+:::{rubric} Tutorials
+:::
+- [Blog: Use CrateDB With DataGrip]
+
+:::{rubric} Product
+:::
+- [CrateDB and DataGrip]
+
+:::{rubric} Notes
+:::
+:::{note}
+We are tracking interoperability issues per [Tool: DataGrip], and appreciate
+any contributions and reports.
+:::
+
+
+[Blog: Use CrateDB With DataGrip]: https://cratedb.com/blog/use-cratedb-with-datagrip-an-advanced-database-ide
+[CrateDB and DataGrip]: https://cratedb.com/integrations/cratedb-and-datagrip
+[CrateDB Cloud]: https://cratedb.com/product/cloud
+[CrateDB JDBC Driver]: https://cratedb.com/docs/jdbc/
+[CrateDB Self-Managed]: https://cratedb.com/product/self-managed
+[crate-jdbc-standalone]: https://repo1.maven.org/maven2/io/crate/crate-jdbc-standalone/
+[crate-jdbc-standalone-2.7.0.jar]: https://repo1.maven.org/maven2/io/crate/crate-jdbc-standalone/2.7.0/crate-jdbc-standalone-2.7.0.jar
+[DataGrip]: https://www.jetbrains.com/datagrip/
+[Tool: DataGrip]: https://github.com/crate/crate/labels/tool%3A%20DataGrip

--- a/docs/integrate/ide.md
+++ b/docs/integrate/ide.md
@@ -1,0 +1,12 @@
+(ide)=
+
+# Database IDEs
+
+Mostly through its PostgreSQL interface, CrateDB supports working with popular
+database IDE (Integrated Development Environment) applications.
+
+```{toctree}
+:maxdepth: 2
+
+datagrip/index
+```

--- a/docs/integrate/index.md
+++ b/docs/integrate/index.md
@@ -9,10 +9,10 @@ This documentation section lists applications, frameworks, and libraries,
 which can be used together with CrateDB, and outlines how to use them
 optimally.
 
-
 ```{toctree}
 :maxdepth: 2
 
+ide
 orm
 df
 etl/index

--- a/docs/migrate/rockset/index.md
+++ b/docs/migrate/rockset/index.md
@@ -328,7 +328,6 @@ and Python example programs.
 [clear commitment]: https://cratedb.com/blog/opensource-licensing-founder
 [Converged Index™]: https://rockset.com/blog/converged-indexing-the-secret-sauce-behind-rocksets-fast-queries/
 [CrateDB]: https://cratedb.com/database
-[CrateDB Cloud]: https://cratedb.com/docs/cloud/
 [CrateDB Editions]: https://cratedb.com/database/editions
 [CrateDB SQL]: project:#sql
 [DX]: https://en.wikipedia.org/wiki/User_experience#Developer_experience


### PR DESCRIPTION
## About
Refactor an item from the [Ecosystem Catalog](https://cratedb.com/docs/clients/) into a dedicated page in the [CrateDB Guide](https://cratedb.com/docs/guide/).

## Preview
https://cratedb-guide--155.org.readthedocs.build/integrate/datagrip/

## References
- GH-157
- https://github.com/crate/crate-clients-tools/pull/157
