### PR TITLE
Integrate: Add dedicated page about DBeaver

### DIFF
--- a/docs/_include/links.md
+++ b/docs/_include/links.md
@@ -7,6 +7,7 @@
 [cloud-datashader-github]: https://github.com/crate/cratedb-examples/blob/amo/cloud-datashader/topic/timeseries/explore/cloud-datashader.ipynb
 [CTE]: inv:crate-reference#sql_dql_with
 [CrateDB Cloud]: https://cratedb.com/product/cloud
+[CrateDB JDBC Driver]: https://cratedb.com/docs/jdbc/
 [CrateDB Self-Managed]: https://cratedb.com/product/self-managed
 [CrateDB's PostgreSQL interface]: inv:crate-reference#interface-postgresql
 [crate-jdbc-standalone]: https://repo1.maven.org/maven2/io/crate/crate-jdbc-standalone/
@@ -41,6 +42,7 @@
 [Multi-model Database]: https://cratedb.com/solutions/multi-model-database
 [nearest neighbor search]: https://en.wikipedia.org/wiki/Nearest_neighbor_search
 [Nested Data Structure]: https://cratedb.com/product/features/nested-data-structure
+[PostgreSQL JDBC Driver]: https://jdbc.postgresql.org/
 [query DSL based on JSON]: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
 [RANK]: inv:crate-reference#window-functions-rank
 [Relational Database]: https://cratedb.com/solutions/relational-database

--- a/docs/integrate/datagrip/index.md
+++ b/docs/integrate/datagrip/index.md
@@ -97,6 +97,5 @@ any contributions and reports.
 
 [Blog: Use CrateDB With DataGrip]: https://cratedb.com/blog/use-cratedb-with-datagrip-an-advanced-database-ide
 [CrateDB and DataGrip]: https://cratedb.com/integrations/cratedb-and-datagrip
-[CrateDB JDBC Driver]: https://cratedb.com/docs/jdbc/
 [DataGrip]: https://www.jetbrains.com/datagrip/
 [Tool: DataGrip]: https://github.com/crate/crate/labels/tool%3A%20DataGrip

--- a/docs/integrate/dbeaver/index.md
+++ b/docs/integrate/dbeaver/index.md
@@ -1,0 +1,87 @@
+(dbeaver)=
+# DBeaver
+
+:::{include} /_include/links.md
+:::
+
+```{div}
+:style: "float: right; margin-left: 0.5em"
+[![](https://upload.wikimedia.org/wikipedia/commons/thumb/b/b5/DBeaver_logo.svg/512px-DBeaver_logo.svg.png){w=120px}](https://dbeaver.io/)
+```
+
+[DBeaver] is a multipurpose cross-platform database tool for developers,
+database administrators, analysts, and everyone working with data.
+
+It is available as an open-source version _DBeaver Community_ and
+as a commercial version _DBeaver PRO_.
+
+
+## Connect
+
+::::{grid} 2
+
+:::{grid-item}
+:columns: 7
+Please specify database URL and credentials of your CrateDB cluster.
+For connecting to CrateDB, the standard [PostgreSQL JDBC Driver]
+will be used.
+
+When connecting to [CrateDB Self-Managed] on localhost,
+for evaluation purposes, use:
+```
+jdbc:postgresql://localhost:5432/crate
+```
+
+When connecting to [CrateDB Cloud], use:
+```
+jdbc:postgresql://<clustername>.cratedb.net:5432/crate
+```
+:::
+:::{grid-item}
+:columns: 5
+![Image](https://github.com/user-attachments/assets/630fcc7c-21c5-4070-be72-e38041c19d8e){w=480px}
+:::
+
+::::
+
+
+## Usage
+Use the tree menu on the left-hand pane to navigate to the `doc` schema and
+its tables. Navigate to the Data tab to browse your table data.
+
+![Image](https://cratedb.com/hs-fs/hubfs/Screen-Shot-2019-04-05-at-17.15.05.png?width=1600&name=Screen-Shot-2019-04-05-at-17.15.05.png){h=240px}
+![Image](https://cratedb.com/hs-fs/hubfs/Screen-Shot-2019-04-05-at-17.15.13.png?width=1600&name=Screen-Shot-2019-04-05-at-17.15.13.png){h=240px}
+
+
+## Learn
+
+:::{rubric} Tutorials
+:::
+- [Blog: Use CrateDB With DBeaver]
+
+:::{rubric} Product
+:::
+- [CrateDB and DBeaver]
+
+:::{rubric} Notes
+:::
+:::{note}
+A few data types of CrateDB need special considerations.
+- `ARRAY` types are recognised as such in reads, also work for inserts through the GUI.
+  They need to use curly brackets syntax `{1,2}` instead of `[1,2]`.
+- `OBJECT` types are seen as string, and are ok to insert via GUI.
+- `GEO_POINT` types are seen as `STRING`, for insert through GUI, please use parentheses.
+- `GEO_SHAPE` types are seen as `STRING`, are ok to insert via GUI.
+- `FLOAT_VECTOR` types are seen as `ARRAY` on read, and can be inserted
+  using the GUI with same considerations as `ARRAY`s.
+:::
+:::{note}
+We are tracking interoperability issues per [Tool: DBeaver], and appreciate
+any contributions and reports.
+:::
+
+
+[Blog: Use CrateDB With DBeaver]: https://cratedb.com/blog/cratedb-dbeaver
+[CrateDB and DBeaver]: https://cratedb.com/integrations/cratedb-and-dbeaver
+[DBeaver]: https://dbeaver.io/
+[Tool: DBeaver]: https://github.com/crate/crate/labels/tool%3A%20DBeaver

--- a/docs/integrate/ide.md
+++ b/docs/integrate/ide.md
@@ -9,4 +9,5 @@ database IDE (Integrated Development Environment) applications.
 :maxdepth: 2
 
 datagrip/index
+dbeaver/index
 ```


### PR DESCRIPTION
## About
Refactor an item from the [Ecosystem Catalog](https://cratedb.com/docs/clients/) into a dedicated page in the [CrateDB Guide](https://cratedb.com/docs/guide/).

## Preview
https://cratedb-guide--157.org.readthedocs.build/integrate/dbeaver/

## References
- GH-155
- https://github.com/crate/crate-clients-tools/pull/157
