### PR TITLE
dbt: Improve wording

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,8 @@ linkcheck_ignore = [
     # -rate limited-, sleeping...
     r"https://medium.com/.*",
     r"http://api.open-notify.org/.*",
+    # Read timed out. (read timeout=15)
+    r"https://azure.microsoft.com/.*",
 ]
 
 # Configure intersphinx.

--- a/docs/integrate/dbt/index.md
+++ b/docs/integrate/dbt/index.md
@@ -128,9 +128,9 @@ the name generation according to your needs.
 
 :::{grid-item}
 :columns: auto auto 8 8
-**Intro to Data Build Tool (dbt)**
+**Introduction to dbt**
 
-Learn how to get started using dbt (data-build-tool) by following along
+Learn how to get started using dbt by following along
 with an easy step-by-step tutorial.
 
 In this video, you will learn how to install dbt, initialize a new project


### PR DESCRIPTION
## About

At https://github.com/dbt-labs/docs.getdbt.com/pull/6564#pullrequestreview-2492313941, @amychen1776 said:

> as a heads up for your own documentation - we no longer called dbt data build tool. It's just dbt and is no longer broken out

This patch intends to fix the wording. Thanks, Amy.
