### PR TITLE
Chore: Fix link checker re. anchor not found on pypi.org

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,11 @@ linkcheck_ignore = [
     r"https://azure.microsoft.com/.*",
 ]
 
+linkcheck_anchors_ignore_for_url += [
+    # Anchor 'XXX' not found
+    r"https://pypi.org/.*"
+]
+
 # Configure intersphinx.
 if "sphinx.ext.intersphinx" not in extensions:
     extensions += ["sphinx.ext.intersphinx"]


### PR DESCRIPTION
## About
Link checker was failing here. Some rendering on PyPI might have changed?

```
(integrate/testing: line   27) broken    https://pypi.org/project/cr8/#run-crate - Anchor 'run-crate' not found
```

-- https://github.com/crate/cratedb-guide/actions/runs/12273753962/job/34255514597?pr=154#step:4:1605