### PR TITLE
LangChain: Update to langchain-cratedb 0.0.0

### DIFF
--- a/docs/integrate/langchain/index.md
+++ b/docs/integrate/langchain/index.md
@@ -49,9 +49,7 @@ build using LLMs:
 
 ## Install
 ```shell
-pip install \
-  'langchain-community @ git+https://github.com/crate-workbench/langchain.git@cratedb#subdirectory=libs/community' \
-  'sqlalchemy-cratedb>=0.40.0'
+pip install --upgrade langchain-cratedb
 ```
 
 


### PR DESCRIPTION
## About
After quite a bit of back and forth, and a slow genesis in general, this subsystem is finally approaching departures to take off.

## Preview
https://cratedb-guide--166.org.readthedocs.build/integrate/langchain/

## References
- https://github.com/crate/cratedb-examples/pull/773