### PR TITLE
Add REGEXP_LIKE to list of Rockset function equivalences

### DIFF
--- a/docs/migrate/rockset/query.md
+++ b/docs/migrate/rockset/query.md
@@ -116,6 +116,7 @@ under a different name, or there may be a simple workaround for your use cases.
 | POSITION(substring IN string)| `strpos(string , substring)`  |
 | POW(x, y)| `power(x,y)`  |
 | RAND()| `random()`  |
+| REGEXP_LIKE(string, pattern) | `string ~ pattern`  |
 | SEQUENCE(start, stop[, step])| `generate_series`  |
 | SIGN(x)| See [^sign] for CrateDB <5.8  |
 | SPLIT(string, delimiter)[index]| `split_part(string, delimiter, index)` |


### PR DESCRIPTION
## About

This add the equivalence for `REGEXP_LIKE` to the page which covers the translation of queries from Rockset

Ref https://docs.rockset.com/documentation/reference/regular-expression-functions


