### PR TITLE
Updated COPY FROM URL for timeseries example.

### DIFF
--- a/docs/domain/timeseries/learn/query.md
+++ b/docs/domain/timeseries/learn/query.md
@@ -74,7 +74,7 @@ Insert the data using the `COPY FROM` SQL statement.
 
 :::{code} sql
 COPY weather_data
-FROM 'https://github.com/crate/cratedb-datasets/raw/main/cloud-tutorials/data_weather.csv.gz'
+FROM 'https://cdn.crate.io/downloads/datasets/cratedb-datasets/cloud-tutorials/data_weather.csv.gz'
 WITH (format='csv', compression='gzip', empty_string_as_null=true);
 :::
 


### PR DESCRIPTION
Updated the `COPY FROM` URL to be the Crate CDN one.