### PR TITLE
Fixed dataset URL in fulltext example to be at the new location.

### DIFF
--- a/docs/feature/search/fts/learn.md
+++ b/docs/feature/search/fts/learn.md
@@ -61,7 +61,7 @@ SQL statement.
 
 :::{code} sql
 COPY netflix_catalog
-FROM 'https://github.com/crate/cratedb-datasets/raw/main/cloud-tutorials/data_netflix.json.gz'
+FROM 'https://cdn.crate.io/downloads/datasets/cratedb-datasets/cloud-tutorials/data_netflix.json.gz'
 WITH (format = 'json', compression='gzip');
 :::
 


### PR DESCRIPTION
Fixed the dataset URL in the fulltext example to be at the new location.

## Summary of the changes / Why this is an improvement


## Checklist

 - [ ] Link to issue this PR refers to (if applicable): Fixes #???
