### PR TITLE
Testing/Java: Add section about `io.crate:crate-testing` package

### DIFF
--- a/docs/integrate/testing.md
+++ b/docs/integrate/testing.md
@@ -5,6 +5,23 @@ Java and Python based test frameworks and libraries that support software
 integration testing with CrateDB.
 
 
+(java-junit)=
+## Java JUnit
+
+The popular [JUnit] framework is supported by *CrateDB Java Testing Classes*,
+provided per [io.crate:crate-testing] package available on Maven Central.
+Its source code is maintained within the [crate-java-testing] repository on GitHub.
+
+The package includes `CrateTestServer` and `CrateTestCluster` classes for use
+as [JUnit external resources]. Both classes download and start CrateDB before
+test execution, and stop CrateDB afterwards.
+
+This example project includes a corresponding setup that you can use right away
+to get started.
+
+- [Using "crate-testing" with CrateDB and JUnit]
+
+
 (python-pytest)=
 ## Python pytest
 
@@ -47,12 +64,17 @@ CrateDB provides Testcontainers implementations for both Java and Python.
 
 
 [cr8]: https://pypi.org/project/cr8/
+[crate-java-testing]: https://github.com/crate/crate-java-testing
+[io.crate:crate-testing]: https://repo1.maven.org/maven2/io/crate/crate-testing/
+[JUnit]: https://en.wikipedia.org/wiki/JUnit
+[JUnit external resources]: https://github.com/junit-team/junit4/wiki/Rules#externalresource-rules
 [pytest]: https://docs.pytest.org/
 [pytest-cratedb]: https://pypi.org/project/pytest-cratedb/
 [run-crate]: https://pypi.org/project/cr8/#run-crate
 [Testcontainers]: https://testcontainers.com/
 [unittest]: https://docs.python.org/3/library/unittest.html
 [Using "cr8" test layers with CrateDB and unittest]: https://github.com/crate/cratedb-examples/tree/main/testing/native/python-unittest
+[Using "crate-testing" with CrateDB and JUnit]: https://github.com/crate/cratedb-examples/tree/main/by-language/java-qa
 [Using "pytest-cratedb" with CrateDB and pytest]: https://github.com/crate/cratedb-examples/tree/main/testing/native/python-pytest
 [Using "Testcontainers for Java" with CrateDB]: https://github.com/crate/cratedb-examples/tree/main/testing/testcontainers/java
 [Using "Testcontainers for Python" with CrateDB and pytest]: https://github.com/crate/cratedb-examples/tree/main/testing/testcontainers/python-pytest

--- a/docs/integrate/visualize/r.rst
+++ b/docs/integrate/visualize/r.rst
@@ -358,7 +358,7 @@ CrateDB.
 
 
 .. _R: https://www.r-project.org/
-.. _RPostgreSQL: https://cran.r-project.org/web/packages/RPostgreSQL/index.html
+.. _RPostgreSQL: https://cran.r-project.org/web/packages/RPostgreSQL/
 .. _iris classification problem: https://en.wikipedia.org/wiki/Iris_flower_data_set
 .. _RStudio: https://rstudio.com/
 .. _caret: https://cran.r-project.org/web/packages/caret/index.html


### PR DESCRIPTION
## About
The canonical documentation page has been erected in a haste, focused on Python and Testcontainers/Java, so it was natural it forgot to educate about the `io.crate:crate-testing` package.

- https://github.com/crate/crate-java-testing
- https://repo1.maven.org/maven2/io/crate/crate-testing/

## Preview
https://cratedb-guide--178.org.readthedocs.build/integrate/testing.html

/cc @seut 