### PR TITLE
Fix link to tarball installation

### DIFF
--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -145,7 +145,7 @@ Please read this section carefully.
 We recommend to use the package-based installation methods for :ref:`install-deb` and
 :ref:`install-rpm`, by subscribing to the corresponding package release channels.
 
-Alternatively, you can also do a `:ref:install-tarball`.
+Alternatively, you can also do an :ref:`install-tarball`.
 
 
 *****


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Before:
<img width="399" alt="Screenshot 2025-03-26 at 08 12 49" src="https://github.com/user-attachments/assets/d88f0915-7772-41b3-8c3f-7eaba56e25fb" />

After:
<img width="509" alt="Screenshot 2025-03-26 at 08 13 50" src="https://github.com/user-attachments/assets/aa46e7a6-7934-4b9b-8b6e-3f5cc4ee6197" />

## Checklist

 - [X] Link to issue this PR refers to (if applicable): Fixes #???
