### PR TITLE
Naming things: Use "Optimization and scaling", not "productizing"

### DIFF
--- a/docs/performance/index.rst
+++ b/docs/performance/index.rst
@@ -16,5 +16,5 @@ performance tuning and sharding.
    inserts/index
    selects
    optimization
-   designing_for_scale
+   scaling
    storage

--- a/docs/performance/scaling.rst
+++ b/docs/performance/scaling.rst
@@ -1,8 +1,8 @@
-.. _topics-to-watch-out-when-productizing-cratedb:
+.. _performance-scaling:
 
-#######################################
- Key design considerations for scaling
-#######################################
+##################
+ Design for scale
+##################
 
 This article explores critical design considerations to successfully scale
 CrateDB in large production environments to ensure performance and reliability


### PR DESCRIPTION
## About

Just a minor adjustment about page names and link anchor labels.