### PR TITLE
Fix broken links: Documentation about CrateDB Edge has been removed

### DIFF
--- a/docs/feature/cloud/index.md
+++ b/docs/feature/cloud/index.md
@@ -68,7 +68,6 @@ needs.
 :::{rubric} CrateDB Cloud
 :::
 - {ref}`cloud:cluster-deployment-marketplace`
-- {ref}`cloud:cloud-on-kubernetes`
 - {ref}`Documentation <cloud:index>`
 - [Web Console]
 

--- a/docs/integrate/visualize/metabase.rst
+++ b/docs/integrate/visualize/metabase.rst
@@ -17,8 +17,8 @@ Prerequisites
 -------------
 
 First, you will need a running cluster. You can use Metabase with both
-:ref:`CrateDB Cloud <cluster-deployment-stripe>` and
-:ref:`cloud:cloud-on-kubernetes`.
+CrateDB self-managed and its managed offering
+:ref:`CrateDB Cloud <cluster-deployment-stripe>`.
 
 To use Metabase, you must have an existing data set in your CrateDB cluster.
 Feel free to use the sample dataset available in the `Cloud Console`_ or


### PR DESCRIPTION
## About
What the title says.

## References
- https://github.com/crate/cloud-docs/pull/97