### PR TITLE
CI: Remove building docs on macOS

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
 
     steps:
       - name: Acquire sources


### PR DESCRIPTION
## About
The CI workflows' intentions here are mostly to run the link checker, so it's not too much connected to covering operating systems.

By removing the checks for macOS, the process will relax pressure on downstream resources, aiming for making it more unlikely to hit rate limiting measures.

## Details
It's not just rate limiting, it's also **429 Too Many Requests**.
```
(integrate/langchain/index: line  141) broken    https://github.com/crate/cratedb-examples/blob/main/topic/machine-learning/llm-langchain/conversational_memory.ipynb -
429 Client Error: Too Many Requests for url: https://github.com/crate/cratedb-examples/blob/main/topic/machine-learning/llm-langchain/conversational_memory.ipynb
```
-- https://github.com/crate/cratedb-guide/actions/runs/14926973334/job/41933954698?pr=199#step:4:1689

## References
- https://github.com/crate/cratedb-guide/pull/199#issuecomment-2866067152