### PR TITLE
Remove duplicate resource links in index.md

### DIFF
--- a/docs/home/index.md
+++ b/docs/home/index.md
@@ -345,17 +345,13 @@ Different client libraries used by canonical guestbook demo web applications.
 
 ----
 
-**Resources:**
-[Academy] • [Blog] • [Community] • [Customers] • [Examples] • 
-[GitHub] • [Guide] • [Support]
+**Other Resources:**
+[Support] • [Blog] • [Customers] • [GitHub]
 
 
-[Academy]: https://learn.cratedb.com/
 [Blog]: https://cratedb.com/blog
-[Community]: https://community.cratedb.com/
 [CrateDB customer stories]: https://www.youtube.com/playlist?list=PLDZqzXOGoWUJrAF_lVx9U6BzAGG9xYz_v
 [Customers]: https://cratedb.com/customers
-[Examples]: https://github.com/crate/cratedb-examples
 [GitHub]: https://github.com/crate
 [Guide]: https://cratedb.com/docs/guide/
 [HTTP protocol]: https://en.wikipedia.org/wiki/HTTP

--- a/docs/home/index.md
+++ b/docs/home/index.md
@@ -341,23 +341,10 @@ Different client libraries used by canonical guestbook demo web applications.
 ::::
 
 
-<br>
-
-----
-
-**Other Resources:**
-[Support] • [Blog] • [Customers] • [GitHub]
-
-
-[Blog]: https://cratedb.com/blog
 [CrateDB customer stories]: https://www.youtube.com/playlist?list=PLDZqzXOGoWUJrAF_lVx9U6BzAGG9xYz_v
-[Customers]: https://cratedb.com/customers
-[GitHub]: https://github.com/crate
-[Guide]: https://cratedb.com/docs/guide/
 [HTTP protocol]: https://en.wikipedia.org/wiki/HTTP
 [Integrations]: #integrate
 [JDBC]: https://en.wikipedia.org/wiki/Java_Database_Connectivity 
 [ODBC]: https://en.wikipedia.org/wiki/Open_Database_Connectivity
 [PostgreSQL wire protocol]: https://www.postgresql.org/docs/current/protocol.html
 [sharing a playlist of videos]: https://www.youtube.com/playlist?list=PL3cZtICBssphXl5rHgsgG9vTNAVTw_Veq
-[Support]: https://cratedb.com/support/


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

The "Resources" contained links to information that was already part of the page. So I removed those duplicate links away for simplicity. So now it's focused on "additional" resources not mentioned on the page already.

UPDATE:
I ended up removing them entirely as they are all both present in the left navbar or the top menu bar and in addition mentioned inside the page.
