### PR TITLE
Integrate: Add page about Django

### DIFF
--- a/docs/integrate/django/index.md
+++ b/docs/integrate/django/index.md
@@ -1,0 +1,36 @@
+(django)=
+# Django
+
+:::{rubric} About
+:::
+
+```{div}
+:style: "float: right; margin-left: 2em"
+[![](https://static.djangoproject.com/img/logos/django-logo-positive.svg){w=180px}](https://www.djangoproject.com/)
+```
+
+[Django] makes it easier to build better web apps more quickly and with less code.
+
+Django is a high-level Python web framework that encourages rapid development and
+clean, pragmatic design. Built by experienced developers, it takes care of much of
+the hassle of web development, so you can focus on writing your app without needing
+to reinvent the wheel. It’s free and open source. 
+
+- **Ridiculously fast**: Django was designed to help developers take applications
+  from concept to completion as quickly as possible.
+
+- **Reassuringly secure**: Django takes security seriously and helps developers
+  avoid many common security mistakes.
+
+- **Exceedingly scalable**: Some of the busiest sites on the web leverage Django’s
+  ability to quickly and flexibly scale.
+
+:::{rubric} Learn
+:::
+
+- [CrateDB Django connector]: Connector backend to use CrateDB as a database in Django ORM.
+
+
+
+[CrateDB Django connector]: https://github.com/crate/cratedb-django
+[Django]: https://www.djangoproject.com/

--- a/docs/integrate/framework.md
+++ b/docs/integrate/framework.md
@@ -26,8 +26,9 @@ A few quick examples about how to use selected frameworks together with CrateDB.
 :::{toctree}
 :maxdepth: 1
 
-plotly/index
+django/index
 gradio/index
+plotly/index
 pyviz/index
 streamlit/index
 :::


### PR DESCRIPTION
## About

Educate users about [cratedb-django](https://github.com/crate/cratedb-django). Thanks, @surister! ✨ 

## Preview

https://cratedb-guide--225.org.readthedocs.build/integrate/django/
