### PR TITLE
Ingest: Add page about ingestion methods

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -307,6 +307,7 @@ use-cases.
 install/index
 connect/index
 getting-started
+Ingestion <ingest/index>
 feature/index
 admin/index
 performance/index

--- a/docs/ingest/index.md
+++ b/docs/ingest/index.md
@@ -1,0 +1,68 @@
+(ingest)=
+# CrateDB data ingestion
+
+:::{include} /_include/styles.html
+:::
+
+All data ingestion methods for CrateDB at a glance.
+
+:::::{grid} 1 2 2 2
+:margin: 4 4 0 0
+:padding: 0
+:gutter: 2
+
+::::{grid-item-card} {material-outlined}`file_upload;2em` Load data using CrateDB
+- {ref}`Import files <crate-reference:sql-copy-from>`
+
+  Load data from the local filesystem or from remote sources using CrateDB's
+  native `COPY FROM` SQL statement.
+
+  **Protocols:** HTTP, FTP, Blob Storage (AWS S3, Azure)
+  <br>
+  **Formats:** CSV, JSON Lines
+
+- {ref}`fdw`
+
+  Make data in remote database servers available as tables within CrateDB.
+  You can then query these foreign tables like regular user tables.
++++
+Data import methods supported by CrateDB natively.
+::::
+
+::::{grid-item-card} {material-outlined}`cloud_upload;2em` Load data using CrateDB Cloud
+- {ref}`Import files <cloud:cluster-import>`
+
+  Managed data loading from remote sources using CrateDB Cloud's ETL subsystem.
+
+  **Protocols:** HTTP, Blob Storage (AWS S3, Azure)
+  <br>
+  **Formats:** CSV, JSON Lines, Parquet
+
+- {ref}`MongoDB CDC integration <cloud:integrations-mongo-cdc>`
+
+  CrateDB Cloud enables continuous data ingestion from MongoDB using Change Data Capture
+  (CDC), providing seamless, real-time synchronization of your data.
++++
+Data import methods provided by CrateDB Cloud.
+::::
+
+::::{grid-item-card} {material-outlined}`arrow_circle_up;2em` Load data using external systems
+- {ref}`Extract Transform Load (ETL) <etl>`
+
+  Ingest data with polyglot data integration platforms or libraries
+  and complete ETL solutions.
+
+- {ref}`cdc`
+
+  Integrate with third-party change-data-capture (CDC) tools.
+
+- {ref}`telemetry`
+
+  Ingest telemetry data—metrics, logs, and traces—from monitoring
+  and sensor collector systems.
+
++++
+Supported industry-standard frameworks and paradigms.
+::::
+
+:::::

--- a/docs/integrate/index.md
+++ b/docs/integrate/index.md
@@ -17,7 +17,7 @@ Frameworks <framework>
 etl/index
 cdc/index
 mcp/index
-Monitoring and Metrics <metrics/index>
+Metrics and Telemetry <telemetry/index>
 Data Visualization <visualize/index>
 bi/index
 lineage/index

--- a/docs/integrate/telemetry/index.md
+++ b/docs/integrate/telemetry/index.md
@@ -1,6 +1,7 @@
 (metrics)=
+(telemetry)=
 (integrate-metrics)=
-# Monitoring and Metrics with CrateDB
+# Store telemetry data in CrateDB
 
 CrateDB integrations with metrics collection agents, brokers, and stores.
 This documentation section lists applications and daemons which can

--- a/docs/integrate/telemetry/index.md
+++ b/docs/integrate/telemetry/index.md
@@ -1,7 +1,7 @@
 (metrics)=
 (telemetry)=
 (integrate-metrics)=
-# Store telemetry data in CrateDB
+# Telemetry data
 
 CrateDB integrations with metrics collection agents, brokers, and stores.
 This documentation section lists applications and daemons which can


### PR DESCRIPTION
## About

Making a start on recent requests about having a page that bundles all data ingestion methods on a single spot.

**Source:** https://cratedb.gitbook.io/cratedb-docs/K3l1K4ZBSqj0AL16dbZi/getting-started/ingesting-data
**Source:** https://cratedb.gitbook.io/cratedb-docs/K3l1K4ZBSqj0AL16dbZi/drivers-and-integrations/data-sources
**Preview:** https://cratedb-guide--230.org.readthedocs.build/ingest/

## Outlook

Future patches will provide curations to recommend canonical ingest methods, preferably of polyglot nature, possibly tailored/native to CrateDB.

## References

- GH-224
