### PR TITLE
Home: Add "Welcome to CrateDB" teaser text

### DIFF
--- a/docs/connect/drivers.md
+++ b/docs/connect/drivers.md
@@ -359,6 +359,6 @@ Ruby on Rails ActiveRecord adapter for CrateDB.
 
 
 ```{tip}
-Please visit the [](#build-status) page for an overview about the integration
+Please visit the :ref:`build-status` page for an overview about the integration
 status of the client drivers listed above, and more.
 ```

--- a/docs/home/index.md
+++ b/docs/home/index.md
@@ -46,9 +46,9 @@ CrateDB was built for speed, scale, and simplicity:
 :::
 CrateDB is used across industries to power:
 
-* Real-time **analytics applications**
-* Elegant **hybrid search applications**
-* Large-scale **IoT platforms**
+* Real-time **dashboards and analytics**
+* Hybrid **search and retrieval experiences**
+* Large-scale **IoT telemetry and analytics**
 * Complex **geospatial applications**
 * Embedded **AI-driven insights**
 * Modern **industrial data backends**
@@ -78,11 +78,11 @@ unique features.
   indexing strategy.
 * The flexible data schema dynamically adapts based on the data you ingest,
   offering seamless integration and instant readiness for analysis.
-* Columnar storage enables fast search query and aggregation performance.
+* Columnar storage enables fast query and aggregation performance.
 * PostgreSQL wire protocol compatibility and an HTTP interface provide versatile
   integration capabilities.
 * AI-ready: The vector store subsystem integrates well
-  with an extensive 3rd party ecosystem of AI/ML frameworks for advanced data
+  with an extensive third-party ecosystem of AI/ML frameworks for advanced data
   analysis and data-driven decisions.
 
 
@@ -133,8 +133,8 @@ Learn about the fundamentals of CrateDB, guided and self-guided.
 :padding: 0
 
 :::{grid-item-card}
-:link: https://cratedb.com/docs/guide/getting-started.html
-:link-alt: Getting started with CrateDB
+:link: getting-started
+:link-type: ref
 :padding: 3
 :class-header: sd-text-center sd-fs-5 sd-align-minor-center sd-font-weight-bold sd-text-capitalize
 :class-body: sd-text-center sd-fs-5
@@ -147,7 +147,8 @@ Learn how to interact with the database for the first time.
 :::
 
 :::{grid-item-card}
-:link: https://cratedb.com/docs/guide/
+:link: index
+:link-type: ref
 :link-alt: The CrateDB Guide
 :padding: 3
 :class-header: sd-text-center sd-fs-5 sd-align-minor-center sd-font-weight-bold sd-text-capitalize
@@ -199,7 +200,8 @@ Learn about the fundamental tools that support working directly with CrateDB.
 :padding: 0
 
 :::{grid-item-card} Admin UI
-:link: https://cratedb.com/docs/crate/admin-ui/
+:link: crate-admin-ui:index
+:link-type: ref
 :link-alt: The CrateDB Admin UI
 :padding: 3
 :class-card: sd-pt-3
@@ -212,7 +214,8 @@ Learn about CrateDB's included web administration interface.
 :::
 
 :::{grid-item-card} Crash CLI
-:link: https://cratedb.com/docs/crate/crash/
+:link: crate-crash:index
+:link-type: ref
 :link-alt: The Crash CLI
 :padding: 3
 :class-card: sd-pt-3
@@ -288,7 +291,7 @@ compatible with [ODBC], [JDBC], and other database API specifications.
 :::
 
 Learn about database client libraries, drivers, adapters, connectors,
-and integrations with 3rd-party applications and frameworks.
+and integrations with third-party applications and frameworks.
 
 ::::{grid} 2 3 3 3
 :padding: 0
@@ -319,7 +322,7 @@ Discover integrations and solutions from the open-source community and CrateDB p
 :class-footer: text-smaller
 {material-outlined}`integration_instructions;3.5em`
 +++
-Learn about the variety of options to connect and integrate with 3rd-party applications.
+Learn about the variety of options to connect and integrate with third-party applications.
 :::
 
 

--- a/docs/home/index.md
+++ b/docs/home/index.md
@@ -18,8 +18,16 @@ search, or large volumes of structured and semi-structured data, CrateDB gives
 you the **power of SQL**, the **scalability of NoSQL**, and the **flexibility
 of a modern data platform**.
 
-## Why CrateDB
+:::::{grid}
+:padding: 4
+:gutter: 2
 
+::::{grid-item}
+:class: rubric-slimmer
+:columns: 6
+
+:::{rubric} Why CrateDB?
+:::
 CrateDB was built for speed, scale, and simplicity:
 
 * **Real-time performance:** Query millions of records per second with sub-second response times.
@@ -28,9 +36,14 @@ CrateDB was built for speed, scale, and simplicity:
 * **Geospatial & time-series**: Native support for IoT, sensor data, and location-based use cases.
 * **Horizontal scalability**: Add nodes effortlessly to handle more data and users.
 * **Resilient and fault-tolerant**: Built-in replication and recovery.
+::::
 
-## What Can You Build?
+::::{grid-item}
+:class: rubric-slimmer
+:columns: 6
 
+:::{rubric} What Can You Build?
+:::
 CrateDB is used across industries to power:
 
 * Real-time **dashboards and analytics**
@@ -38,6 +51,10 @@ CrateDB is used across industries to power:
 * Complex **geospatial applications**
 * Embedded **AI-driven insights**
 * Modern **industrial data backends**
+::::
+
+:::::
+
 
 ## Get Started
 

--- a/docs/home/index.md
+++ b/docs/home/index.md
@@ -56,6 +56,35 @@ CrateDB is used across industries to power:
 :::::
 
 
+:::{rubric} Benefits and Features
+:::
+
+Whether you are a developer,
+database administrator, or just starting your journey with CrateDB, our
+documentation provides the information and knowledge needed to build
+real-time analytics and hybrid search applications that leverage CrateDB's
+unique features.
+
+* In a unified data platform approach, CrateDB includes analyzing relational, JSON,
+  time-series, geospatial, full-text, and vector data within a single system,
+  eliminating the need for multiple databases.
+* The fully distributed SQL query engine, built on top of Apache Lucene,
+  and inheriting technologies from Elasticsearch/OpenSearch, provides performant
+  aggregations and advanced SQL features like JOINs and CTEs on large datasets
+  of semi-structured data.
+* Real-time indexing automatically indexes all columns, including nested
+  structures, as data is ingested, eliminating the need to worry about
+  indexing strategy.
+* The flexible data schema dynamically adapts based on the data you ingest,
+  offering seamless integration and instant readiness for analysis.
+* Columnar storage enables fast search query and aggregation performance.
+* PostgreSQL wire protocol compatibility and a HTTP interface provide versatile
+  integration capabilities.
+* AI-ready: The vector store subsystem integrates well
+  with an extensive 3rd party ecosystem of AI/ML frameworks for advanced data
+  analysis and data-driven decisions.
+
+
 ## Get Started
 
 We've put together some helpful guides to help you set up your CrateDB instance
@@ -91,88 +120,6 @@ and various connectors to import data.
 
 Helpful guides about how to start working with your database cluster.
 :::
-
-## Overview
-
-Welcome to the official CrateDB Documentation. Whether you are a developer,
-database administrator, or just starting your journey with CrateDB, our
-documentation provides the information and knowledge needed to build
-real-time analytics and hybrid search applications that leverage CrateDB's
-unique features.
-
-:::{rubric} Benefits
-:::
-* In a unified data platform approach, CrateDB includes analyzing relational, JSON,
-  time-series, geospatial, full-text, and vector data within a single system,
-  eliminating the need for multiple databases.
-* The fully distributed SQL query engine, built on top of Apache Lucene,
-  and inheriting technologies from Elasticsearch/OpenSearch, provides performant
-  aggregations and advanced SQL features like JOINs and CTEs on large datasets
-  of semi-structured data.
-* Real-time indexing automatically indexes all columns, including nested
-  structures, as data is ingested, eliminating the need to worry about
-  indexing strategy.
-* The flexible data schema dynamically adapts based on the data you ingest,
-  offering seamless integration and instant readiness for analysis.
-* Columnar storage enables fast search query and aggregation performance.
-* PostgreSQL wire protocol compatibility and a HTTP interface provide versatile
-  integration capabilities.
-* AI-ready: The vector store subsystem integrates well
-  with an extensive 3rd party ecosystem of AI/ML frameworks for advanced data
-  analysis and data-driven decisions.
-
-:::{rubric} Resources
-:::
-
-::::::{grid} 1
-:margin: 1
-:padding: 2
-
-:::::{grid-item}
-:margin: 0
-:padding: 2
-
-::::{grid} 2
-:margin: 0
-:padding: 0
-
-:::{grid-item-card} {material-outlined}`lightbulb;1.7em` Database Features
-:link: https://cratedb.com/docs/guide/feature/
-:link-alt: Database Features
-:class-title: sd-fs-5
-
-Explore all functional, operational and advanced features of CrateDB at a glance.
-:::
-
-:::{grid-item-card} {material-outlined}`auto_stories;1.7em` Database Manual
-:link: https://cratedb.com/docs/reference/
-:link-alt: Database Manual
-:class-title: sd-fs-5
-
-Learn core CrateDB concepts, including data modeling, querying data,
-aggregations, sharding, and more.
-:::
-
-::::
-:::::
-
-:::{grid-item-card} {material-outlined}`link;1.7em` Client Libraries
-:link: https://cratedb.com/docs/crate/clients-tools/en/latest/connect/
-:link-alt: CrateDB: Client Drivers and Libraries
-:padding: 2
-:class-title: sd-fs-5
-
-Learn how to connect your applications using database drivers, libraries,
-adapters, and connectors.
-
-CrateDB supports both the [HTTP protocol] and the [PostgreSQL wire protocol],
-ensuring compatibility with many PostgreSQL clients.
-
-Through corresponding drivers and adapters, CrateDB is compatible with [ODBC],
-[JDBC], and other database API specifications.
-:::
-
-::::::
 
 
 ## Learn
@@ -277,6 +224,63 @@ A command-line interface (CLI) tool for working with CrateDB.
 :::
 
 ::::
+
+
+:::{rubric} Resources
+:::
+
+::::::{grid} 1
+:margin: 1
+:padding: 2
+
+:::::{grid-item}
+:margin: 0
+:padding: 2
+
+::::{grid} 2
+:margin: 0
+:padding: 0
+
+:::{grid-item-card} {material-outlined}`lightbulb;1.7em` Database Features
+:link: features
+:link-type: ref
+:link-alt: Database Features
+:class-title: sd-fs-5
+
+Explore all functional, operational and advanced features of CrateDB at a glance.
+:::
+
+:::{grid-item-card} {material-outlined}`auto_stories;1.7em` Database Manual
+:link: crate-reference:index
+:link-type: ref
+:link-alt: Database Manual
+:class-title: sd-fs-5
+
+Learn core CrateDB concepts, including data modeling, querying data,
+aggregations, sharding, and more.
+:::
+
+::::
+:::::
+
+:::{grid-item-card} {material-outlined}`link;1.7em` Connectivity Options
+:link: connect
+:link-type: ref
+:link-alt: CrateDB: Client Drivers and Libraries
+:padding: 2
+:class-title: sd-fs-5
+
+Learn how to connect your applications using database drivers, libraries,
+adapters, and connectors.
+
+CrateDB supports both the [HTTP protocol] and the [PostgreSQL wire protocol],
+ensuring compatibility with many PostgreSQL clients.
+
+Through corresponding drivers, adapters, and client libraries, CrateDB is
+compatible with [ODBC], [JDBC], and other database API specifications.
+:::
+
+::::::
 
 
 :::{rubric} Drivers and Integrations

--- a/docs/home/index.md
+++ b/docs/home/index.md
@@ -3,13 +3,6 @@ orphan: true
 ---
 
 
-<style>
-/* Cards with links */
-.sd-hide-link-text {
-  height: 0;
-}
-</style>
-
 # Welcome to CrateDB
 
 CrateDB is a **distributed SQL database** designed for **real-time analytics
@@ -50,8 +43,8 @@ CrateDB is used across industries to power:
 * Hybrid **search and retrieval experiences**
 * Large-scale **IoT telemetry and analytics**
 * Complex **geospatial applications**
-* Embedded **AI-driven insights**
-* Modern **industrial data backends**
+* **AI-powered features** embedded in your apps
+* **Industrial IoT** data backends
 ::::
 
 :::::
@@ -360,7 +353,7 @@ Learn how to use CrateDB by digesting concise examples.
 :class-footer: text-smaller
 {material-outlined}`play_circle;3.5em`
 +++
-A collection of clear and concise examples how to work with CrateDB.
+A collection of clear, concise examples of how to work with CrateDB.
 :::
 
 :::{grid-item-card} Sample Apps
@@ -373,7 +366,7 @@ A collection of clear and concise examples how to work with CrateDB.
 :class-footer: text-smaller
 {material-outlined}`apps;3.5em`
 +++
-Different client libraries used by canonical guestbook demo web applications. 
+Canonical guestbook demo applications implemented with different client libraries.
 :::
 
 ::::

--- a/docs/home/index.md
+++ b/docs/home/index.md
@@ -13,7 +13,7 @@ orphan: true
 # Welcome to CrateDB
 
 CrateDB is a **distributed SQL database** designed for **real-time analytics
-and search** at scale. Whether you're working with time-series data, full-text
+and search** at scale. Whether you are working with time-series data, full-text
 search, or large volumes of structured and semi-structured data, CrateDB gives
 you the **power of SQL**, the **scalability of NoSQL**, and the **flexibility
 of a modern data platform**.
@@ -46,7 +46,8 @@ CrateDB was built for speed, scale, and simplicity:
 :::
 CrateDB is used across industries to power:
 
-* Real-time **dashboards and analytics**
+* Real-time **analytics applications**
+* Elegant **hybrid search applications**
 * Large-scale **IoT platforms**
 * Complex **geospatial applications**
 * Embedded **AI-driven insights**

--- a/docs/home/index.md
+++ b/docs/home/index.md
@@ -10,7 +10,72 @@ orphan: true
 }
 </style>
 
-# CrateDB Documentation
+# Welcome to CrateDB
+
+CrateDB is a **distributed SQL database** designed for **real-time analytics
+and search** at scale. Whether you're working with time-series data, full-text
+search, or large volumes of structured and semi-structured data, CrateDB gives
+you the **power of SQL**, the **scalability of NoSQL**, and the **flexibility
+of a modern data platform**.
+
+## Why CrateDB
+
+CrateDB was built for speed, scale, and simplicity:
+
+* **Real-time performance:** Query millions of records per second with sub-second response times.
+* **AI/ML-ready:** Store and serve data for modern AI pipelines.
+* **Search + SQL**: Combine full-text search with rich SQL queries.
+* **Geospatial & time-series**: Native support for IoT, sensor data, and location-based use cases.
+* **Horizontal scalability**: Add nodes effortlessly to handle more data and users.
+* **Resilient and fault-tolerant**: Built-in replication and recovery.
+
+## What Can You Build?
+
+CrateDB is used across industries to power:
+
+* Real-time **dashboards and analytics**
+* Large-scale **IoT platforms**
+* Complex **geospatial applications**
+* Embedded **AI-driven insights**
+* Modern **industrial data backends**
+
+## Get Started
+
+We've put together some helpful guides for you to setup your CrateDB instance
+quickly and easily. Enjoy the reading!
+
+:::{card} {material-outlined}`rocket_launch;1.7em` CrateDB Cloud
+:link: cloud-docs-index
+:link-type: ref
+:link-alt: CrateDB Cloud
+:class-title: sd-fs-5
+
+Start with a fully managed CrateDB instance to accelerate and simplify working
+with analytical data. CrateDB Cloud enables seamless deployment, monitoring,
+backups, and scaling of CrateDB clusters on AWS, Azure or GCPs, eliminating
+the need for direct database management.
+
+With CrateDB Cloud, you can skip infrastructure setup and focus on delivering
+value for your business with a query console, SQL Scheduler, table policies
+and various connectors to import data.
++++
+```{button-link} https://cratedb.com/docs/cloud/tutorials/quick-start.html
+:color: primary
+:expand:
+**Start forever free cluster with 8 GB of storage**
+```
+:::
+
+:::{card} {material-outlined}`not_started;1.7em` Getting Started
+:link: getting-started
+:link-type: ref
+:link-alt: CrateDB Cloud
+:class-title: sd-fs-5
+
+Helpful guides about how to start working with your database cluster.
+:::
+
+## Details
 
 Welcome to the official CrateDB Documentation. Whether you are a developer,
 database administrator, or just starting your journey with CrateDB, our
@@ -39,33 +104,12 @@ unique features.
   with an extensive 3rd party ecosystem of AI/ML frameworks for advanced data
   analysis and data-driven decisions.
 
+:::{rubric} Resources
+:::
 
 ::::::{grid} 1
 :margin: 1
 :padding: 2
-
-:::{grid-item-card} {material-outlined}`rocket_launch;1.7em` CrateDB Cloud
-:link: cloud-docs-index
-:link-type: ref
-:link-alt: CrateDB Cloud
-:padding: 2
-:class-title: sd-fs-5
-
-Start with a fully managed CrateDB instance to accelerate and simplify working
-with analytical data. CrateDB Cloud enables seamless deployment, monitoring,
-backups, and scaling of CrateDB clusters on AWS, Azure or GCPs, eliminating
-the need for direct database management.
-
-With CrateDB Cloud, you can skip infrastructure setup and focus on delivering
-value for your business with a query console, SQL Scheduler, table policies
-and various connectors to import data.
-+++
-```{button-link} https://cratedb.com/docs/cloud/tutorials/quick-start.html
-:color: primary
-:expand:
-**Start forever free cluster with 8 GB of storage**
-```
-:::
 
 :::::{grid-item}
 :margin: 0

--- a/docs/home/index.md
+++ b/docs/home/index.md
@@ -66,8 +66,8 @@ documentation provides the information and knowledge needed to build
 real-time analytics and hybrid search applications that leverage CrateDB's
 unique features.
 
-* In a unified data platform approach, CrateDB includes analyzing relational, JSON,
-  time-series, geospatial, full-text, and vector data within a single system,
+* In a unified data platform, CrateDB lets you analyze relational, JSON,
+  time-series, geospatial, full-text, and vector data in a single system,
   eliminating the need for multiple databases.
 * The fully distributed SQL query engine, built on top of Apache Lucene,
   and inheriting technologies from Elasticsearch/OpenSearch, provides performant
@@ -79,7 +79,7 @@ unique features.
 * The flexible data schema dynamically adapts based on the data you ingest,
   offering seamless integration and instant readiness for analysis.
 * Columnar storage enables fast search query and aggregation performance.
-* PostgreSQL wire protocol compatibility and a HTTP interface provide versatile
+* PostgreSQL wire protocol compatibility and an HTTP interface provide versatile
   integration capabilities.
 * AI-ready: The vector store subsystem integrates well
   with an extensive 3rd party ecosystem of AI/ML frameworks for advanced data
@@ -88,7 +88,7 @@ unique features.
 
 ## Get Started
 
-We've put together some helpful guides to help you set up your CrateDB instance
+We've put together guides to help you set up your CrateDB instance
 quickly and easily. Enjoy reading!
 
 :::{card} {material-outlined}`rocket_launch;1.7em` CrateDB Cloud
@@ -99,7 +99,7 @@ quickly and easily. Enjoy reading!
 
 Start with a fully managed CrateDB instance to accelerate and simplify working
 with analytical data. CrateDB Cloud enables seamless deployment, monitoring,
-backups, and scaling of CrateDB clusters on AWS, Azure or GCPs, eliminating
+backups, and scaling of CrateDB clusters on AWS, Azure, or GCP, eliminating
 the need for direct database management.
 
 With CrateDB Cloud, you can skip infrastructure setup and focus on delivering
@@ -347,7 +347,7 @@ Learn how to use CrateDB by digesting concise examples.
 ::::{grid} 2 3 3 3
 :padding: 0
 
-:::{grid-item-card} CrateDB Examples 
+:::{grid-item-card} CrateDB Examples
 :link: https://github.com/crate/cratedb-examples
 :link-alt: CrateDB Examples
 :padding: 3
@@ -360,7 +360,7 @@ Learn how to use CrateDB by digesting concise examples.
 A collection of clear and concise examples how to work with CrateDB.
 :::
 
-:::{grid-item-card} Sample Apps 
+:::{grid-item-card} Sample Apps
 :link: https://github.com/crate/crate-sample-apps/
 :link-alt: CrateDB Sample Apps
 :padding: 3
@@ -409,7 +409,6 @@ Make sure you also do not miss relevant [CrateDB customer stories].
 
 [CrateDB customer stories]: https://www.youtube.com/playlist?list=PLDZqzXOGoWUJrAF_lVx9U6BzAGG9xYz_v
 [HTTP protocol]: https://en.wikipedia.org/wiki/HTTP
-[Integrations]: #integrate
 [JDBC]: https://en.wikipedia.org/wiki/Java_Database_Connectivity 
 [ODBC]: https://en.wikipedia.org/wiki/Open_Database_Connectivity
 [PostgreSQL wire protocol]: https://www.postgresql.org/docs/current/protocol.html

--- a/docs/home/index.md
+++ b/docs/home/index.md
@@ -41,11 +41,11 @@ CrateDB is used across industries to power:
 
 ## Get Started
 
-We've put together some helpful guides for you to setup your CrateDB instance
-quickly and easily. Enjoy the reading!
+We've put together some helpful guides to help you set up your CrateDB instance
+quickly and easily. Enjoy reading!
 
 :::{card} {material-outlined}`rocket_launch;1.7em` CrateDB Cloud
-:link: cloud-docs-index
+:link: cloud:index
 :link-type: ref
 :link-alt: CrateDB Cloud
 :class-title: sd-fs-5
@@ -62,20 +62,20 @@ and various connectors to import data.
 ```{button-link} https://cratedb.com/docs/cloud/tutorials/quick-start.html
 :color: primary
 :expand:
-**Start forever free cluster with 8 GB of storage**
+**Start a forever-free cluster with 8 GB of storage**
 ```
 :::
 
 :::{card} {material-outlined}`not_started;1.7em` Getting Started
 :link: getting-started
 :link-type: ref
-:link-alt: CrateDB Cloud
+:link-alt: Getting started with CrateDB
 :class-title: sd-fs-5
 
 Helpful guides about how to start working with your database cluster.
 :::
 
-## Details
+## Overview
 
 Welcome to the official CrateDB Documentation. Whether you are a developer,
 database administrator, or just starting your journey with CrateDB, our


### PR DESCRIPTION
## About
This patch is implementing a suggestion to add a preamble to the "Home" page of the CrateDB Guide. It includes two sections "Why CrateDB?" and "What Can You Build?".

**Source:** https://cratedb.gitbook.io/cratedb-docs/K3l1K4ZBSqj0AL16dbZi
**Preview:** https://cratedb-guide--234.org.readthedocs.build/home/

## References
- GH-227