### PR TITLE
Integrate/MongoDB: Simplify starter tutorial

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,6 +65,8 @@ linkcheck_ignore += [
     r"https://www.amqp.org/",
     # "We are currently migrating Datatracker and Mail Archive to a new cloud provider."
     r"https://datatracker.ietf.org",
+    # 403 Client Error: Forbidden
+    r"https://www.sqlalchemy.org/",
 ]
 
 linkcheck_anchors_ignore_for_url += [

--- a/docs/integrate/mongodb/cloud.md
+++ b/docs/integrate/mongodb/cloud.md
@@ -1,7 +1,7 @@
 # Cloud to Cloud
 
 The procedure for importing data from [MongoDB Atlas] into [CrateDB Cloud] is
-similar like the {ref}`standalone variant <mongodb-tutorial>`, with a few small
+similar to the {ref}`standalone variant <mongodb-tutorial>`, with a few small
 adjustments.
 
 First, helpful aliases:
@@ -19,9 +19,9 @@ These are, with examples:
 * Password: `<CRATEDB_PASSWORD>`
 
 **MongoDB Atlas**
-  * Host: `<MONGODB_ATLAS_HOST>`
-  * User: `<MONGODB_USER>`
-  * Password: `<MONGODB_PASSWORD>`
+* Host: `<MONGODB_ATLAS_HOST>`
+* User: `<MONGODB_USER>`
+* Password: `<MONGODB_PASSWORD>`
 
 For CrateDB, the credentials are displayed at time of cluster creation.
 For MongoDB, they can be found in the [cloud platform] itself.

--- a/docs/integrate/mongodb/cloud.md
+++ b/docs/integrate/mongodb/cloud.md
@@ -1,0 +1,50 @@
+# Cloud to Cloud
+
+The procedure for importing data from [MongoDB Atlas] into [CrateDB Cloud] is
+similar, with a few small adjustments.
+
+First, helpful aliases again:
+:::{code} shell
+alias ctk="docker run --rm -it ghcr.io/crate/cratedb-toolkit ctk"
+alias crash="docker run --rm -it ghcr.io/crate-workbench/cratedb-toolkit crash"
+:::
+
+You will need your credentials for both CrateDB and MongoDB. 
+These are, with examples:
+
+**CrateDB Cloud**
+* Host: ```gray-wicket.aks1.westeurope.azure.cratedb.net```
+* Username: ```admin```
+* Password: ```-9..nn```
+
+**MongoDB Atlas**
+  * Host: ```cluster0.nttj7.mongodb.net```
+  * User: ```admin```
+  * Password: ```a1..d1```
+
+For CrateDB, the credentials are displayed at time of cluster creation.
+For MongoDB, they can be found in the [cloud platform] itself.
+
+Now, same as before, import data from MongoDB database/collection into 
+CrateDB schema/table.
+:::{code} shell
+ctk load table \
+  "mongodb+srv://admin:a..1@cluster0.nttj7.mongodb.net/testdrive/demo" \
+  --cluster-url='crate://admin:-..n@gray-wicket.aks1.westeurope.azure.cratedb.net:4200/testdrive/demo?ssl=true'
+:::
+
+::: {note}
+Note the **necessary** `ssl=true` query parameter at the end of both database connection URLs
+when working on Cloud-to-Cloud transfers.
+:::
+
+Verify that relevant data has been transferred to CrateDB.
+:::{code} shell
+crash --hosts 'https://admin:-..n@gray-wicket.aks1.westeurope.azure.cratedb.net:4200' --command 'SELECT * FROM testdrive.demo;'
+:::
+
+
+
+[cloud platform]: https://cloud.mongodb.com
+[CrateDB Cloud]: https://console.cratedb.cloud/
+[MongoDB Atlas]: https://www.mongodb.com/cloud/atlas

--- a/docs/integrate/mongodb/cloud.md
+++ b/docs/integrate/mongodb/cloud.md
@@ -1,15 +1,16 @@
 # Cloud to Cloud
 
 The procedure for importing data from [MongoDB Atlas] into [CrateDB Cloud] is
-similar, with a few small adjustments.
+similar like the {ref}`standalone variant <mongodb-tutorial>`, with a few small
+adjustments.
 
-First, helpful aliases again:
+First, helpful aliases:
 ```shell
 alias crash="docker run --rm -it ghcr.io/crate-workbench/cratedb-toolkit crash"
 alias ctk="docker run --rm -i ghcr.io/crate/cratedb-toolkit ctk"
 ```
 
-You will need your credentials for both CrateDB and MongoDB. 
+You will need credentials for both CrateDB and MongoDB.
 These are, with examples:
 
 **CrateDB Cloud**

--- a/docs/integrate/mongodb/cloud.md
+++ b/docs/integrate/mongodb/cloud.md
@@ -4,45 +4,44 @@ The procedure for importing data from [MongoDB Atlas] into [CrateDB Cloud] is
 similar, with a few small adjustments.
 
 First, helpful aliases again:
-:::{code} shell
-alias ctk="docker run --rm -it ghcr.io/crate/cratedb-toolkit ctk"
+```shell
 alias crash="docker run --rm -it ghcr.io/crate-workbench/cratedb-toolkit crash"
-:::
+alias ctk="docker run --rm -i ghcr.io/crate/cratedb-toolkit ctk"
+```
 
 You will need your credentials for both CrateDB and MongoDB. 
 These are, with examples:
 
 **CrateDB Cloud**
-* Host: ```gray-wicket.aks1.westeurope.azure.cratedb.net```
-* Username: ```admin```
-* Password: ```-9..nn```
+* Host: `<CRATEDB_CLOUD_HOST>`
+* Username: `<CRATEDB_USER>`
+* Password: `<CRATEDB_PASSWORD>`
 
 **MongoDB Atlas**
-  * Host: ```cluster0.nttj7.mongodb.net```
-  * User: ```admin```
-  * Password: ```a1..d1```
+  * Host: `<MONGODB_ATLAS_HOST>`
+  * User: `<MONGODB_USER>`
+  * Password: `<MONGODB_PASSWORD>`
 
 For CrateDB, the credentials are displayed at time of cluster creation.
 For MongoDB, they can be found in the [cloud platform] itself.
 
 Now, same as before, import data from MongoDB database/collection into 
 CrateDB schema/table.
-:::{code} shell
+```shell
 ctk load table \
   "mongodb+srv://admin:a..1@cluster0.nttj7.mongodb.net/testdrive/demo" \
   --cluster-url='crate://admin:-..n@gray-wicket.aks1.westeurope.azure.cratedb.net:4200/testdrive/demo?ssl=true'
-:::
+```
 
-::: {note}
-Note the **necessary** `ssl=true` query parameter at the end of both database connection URLs
-when working on Cloud-to-Cloud transfers.
+:::{note}
+CrateDB Cloud requires `ssl=true` in the cluster URL. For MongoDB Atlas SRV URIs
+(`mongodb+srv://`), TLS is implied and no extra parameter is needed.
 :::
 
 Verify that relevant data has been transferred to CrateDB.
-:::{code} shell
+```shell
 crash --hosts 'https://admin:-..n@gray-wicket.aks1.westeurope.azure.cratedb.net:4200' --command 'SELECT * FROM testdrive.demo;'
-:::
-
+```
 
 
 [cloud platform]: https://cloud.mongodb.com

--- a/docs/integrate/mongodb/index.md
+++ b/docs/integrate/mongodb/index.md
@@ -94,6 +94,8 @@ into CrateDB (`cdc`), optionally using transformations.
 :maxdepth: 1
 :hidden:
 Tutorial <tutorial>
+cloud
+model
 :::
 
 
@@ -101,4 +103,12 @@ Tutorial <tutorial>
 **Blog:** [Announcing MongoDB CDC Integration (Public Preview) in CrateDB Cloud]
 :::
 
+:::{note}
+The MongoDB I/O subsystem is based on the [migr8] migration utility package. Please also
+check its documentation to learn about more of its capabilities, supporting
+you when working with MongoDB.
+:::
+
+
 [Announcing MongoDB CDC Integration (Public Preview) in CrateDB Cloud]: https://cratedb.com/blog/announcing-mongodb-cdc-integration-public-preview-in-cratedb-cloud
+[migr8]: https://cratedb-toolkit.readthedocs.io/io/mongodb/migr8.html

--- a/docs/integrate/mongodb/index.md
+++ b/docs/integrate/mongodb/index.md
@@ -104,9 +104,8 @@ model
 :::
 
 :::{note}
-The MongoDB I/O subsystem is based on the [migr8] migration utility package. Please also
-check its documentation to learn about more of its capabilities, supporting
-you when working with MongoDB.
+The MongoDB I/O subsystem is based on the [migr8] migration utility package. Consult its
+documentation for advanced capabilities when working with MongoDB.
 :::
 
 

--- a/docs/integrate/mongodb/index.md
+++ b/docs/integrate/mongodb/index.md
@@ -104,7 +104,7 @@ model
 :::
 
 :::{note}
-The MongoDB I/O subsystem is based on the [migr8] migration utility package. Consult its
+The MongoDB I/O component is based on the [migr8] migration utility package. Consult its
 documentation for advanced capabilities when working with MongoDB.
 :::
 

--- a/docs/integrate/mongodb/model.md
+++ b/docs/integrate/mongodb/model.md
@@ -1,0 +1,26 @@
+# MongoDB's data model
+
+MongoDB stores data in collections and documents. CrateDB stores
+data in schemas and tables.
+
+- A **database** in MongoDB is a physical container for collections, similar 
+  to a schema in CrateDB, which groups tables together within a database.
+- A **collection** in MongoDB is a grouping of documents, similar to a table 
+  in CrateDB, which is a structured collection of rows.
+- A **document** in MongoDB is a record in a collection, similar to a row in 
+  a CrateDB table. It is a set of key-value pairs, where each key represents
+  a field, and the value represents the data.
+- A **field** in MongoDB is similar to a column in a CrateDB table. In both
+  systems, fields (or columns) define the attributes for the records
+  (or rows/documents).
+- A **primary key** in MongoDB is typically the _id field, which uniquely 
+  identifies a document within a collection. In CrateDB, a primary key 
+  uniquely identifies a row in a table.
+- An **index** in MongoDB is similar to an index in CrateDB. Both are used to
+  improve query performance by providing a fast lookup for fields (or columns)
+  within documents (or rows).
+
+-- [Databases and Collections]
+
+
+[Databases and Collections]: https://www.mongodb.com/docs/manual/core/databases-and-collections/

--- a/docs/integrate/mongodb/model.md
+++ b/docs/integrate/mongodb/model.md
@@ -3,24 +3,27 @@
 MongoDB stores data in collections and documents. CrateDB stores
 data in schemas and tables.
 
-- A **database** in MongoDB is a physical container for collections, similar 
-  to a schema in CrateDB, which groups tables together within a database.
-- A **collection** in MongoDB is a grouping of documents, similar to a table 
+- A **database** in MongoDB is a physical container for collections, roughly
+  corresponding to a schema in CrateDB, which groups tables together.
+- A **collection** in MongoDB is a grouping of documents, similar to a table
   in CrateDB, which is a structured collection of rows.
 - A **document** in MongoDB is a record in a collection, similar to a row in 
-  a CrateDB table. It is a set of key-value pairs, where each key represents
-  a field, and the value represents the data.
+  a CrateDB table. It is a set of key-value pairs. Note: Nested structures can
+  be modeled in CrateDB using OBJECT columns when appropriate.
 - A **field** in MongoDB is similar to a column in a CrateDB table. In both
   systems, fields (or columns) define the attributes for the records
   (or rows/documents).
-- A **primary key** in MongoDB is typically the _id field, which uniquely 
-  identifies a document within a collection. In CrateDB, a primary key 
+- A **primary key** in MongoDB is typically the `_id` field, which uniquely
+  identifies a document within a collection. In CrateDB, a primary key
   uniquely identifies a row in a table.
 - An **index** in MongoDB is similar to an index in CrateDB. Both are used to
   improve query performance by providing a fast lookup for fields (or columns)
   within documents (or rows).
 
+
+:::{seealso}
 -- [Databases and Collections]
+:::
 
 
 [Databases and Collections]: https://www.mongodb.com/docs/manual/core/databases-and-collections/

--- a/docs/integrate/mongodb/model.md
+++ b/docs/integrate/mongodb/model.md
@@ -1,7 +1,7 @@
 # MongoDB's data model
 
 MongoDB stores data in collections and documents. CrateDB stores
-data in schemas and tables.
+data in tables and rows.
 
 - A **database** in MongoDB is a physical container for collections, roughly
   corresponding to a schema in CrateDB, which groups tables together.

--- a/docs/integrate/mongodb/tutorial.md
+++ b/docs/integrate/mongodb/tutorial.md
@@ -67,26 +67,26 @@ doskey mongosh=docker run --rm -it --network=cratedb-demo docker.io/mongo mongos
 
 Insert a record into a MongoDB collection; you can repeat this step as needed.
 ```shell
-mongosh --host mongodb --eval 'db.testdrive.insert({"temperature": 42.84, "humidity": 83.1})'
+mongosh --host mongodb --db test --eval 'db.demo.insert({"temperature": 42.84, "humidity": 83.1})'
 ```
 
 Invoke the data transfer pipeline.
 ```shell
 ctk load table \
-  "mongodb://mongodb/test/testdrive" \
-  --cluster-url="crate://cratedb/doc/testdrive"
+  "mongodb://mongodb/test/demo" \
+  --cluster-url="crate://cratedb/doc/mongodb_demo"
 ```
 
 Inspect data stored in CrateDB.
 ```shell
-crash --hosts cratedb -c "SELECT * FROM doc.testdrive"
+crash --hosts cratedb -c "SELECT * FROM doc.mongodb_demo"
 ```
 
 
 :::{tip}
 To bulk import example data into the same database and collection used above:
 ```shell
-mongoimport --db testdrive --collection demo --file demodata.json --jsonArray
+mongoimport --db test --collection demo --file demodata.json --jsonArray
 ```
 Note: `mongoimport` is part of the [MongoDB Database tools].
 :::

--- a/docs/integrate/mongodb/tutorial.md
+++ b/docs/integrate/mongodb/tutorial.md
@@ -38,11 +38,11 @@ programs.
 ::::{tab-set}
 
 :::{tab-item} Linux and macOS
-To make the settings persistent, add them to your Shell profile (`~/.profile`).
+To make the settings persistent, add them to your shell profile (e.g., `~/.profile` or `~/.zshrc`).
 ```shell
 alias crash="docker run --rm -it --network=cratedb-demo ghcr.io/crate/cratedb-toolkit crash"
 alias ctk="docker run --rm -i --network=cratedb-demo ghcr.io/crate/cratedb-toolkit ctk"
-alias mongosh="docker run --rm -i --network=cratedb-demo docker.io/mongo mongosh"
+alias mongosh="docker run --rm -it --network=cratedb-demo docker.io/mongo mongosh"
 ```
 :::
 :::{tab-item} Windows PowerShell
@@ -50,14 +50,14 @@ To make the settings persistent, add them to your PowerShell profile (`$PROFILE`
 ```powershell
 function crash { docker run --rm -it --network=cratedb-demo ghcr.io/crate/cratedb-toolkit crash @args }
 function ctk { docker run --rm -i --network=cratedb-demo ghcr.io/crate/cratedb-toolkit ctk @args }
-function mongosh { docker run --rm -i --network=cratedb-demo docker.io/mongo mongosh @args }
+function mongosh { docker run --rm -it --network=cratedb-demo docker.io/mongo mongosh @args }
 ```
 :::
 :::{tab-item} Windows Command
 ```shell
 doskey crash=docker run --rm -it --network=cratedb-demo ghcr.io/crate/cratedb-toolkit crash $*
 doskey ctk=docker run --rm -i --network=cratedb-demo ghcr.io/crate/cratedb-toolkit ctk $*
-doskey mongosh=docker run --rm -i --network=cratedb-demo docker.io/mongo mongosh $*
+doskey mongosh=docker run --rm -it --network=cratedb-demo docker.io/mongo mongosh $*
 ```
 :::
 
@@ -65,7 +65,7 @@ doskey mongosh=docker run --rm -i --network=cratedb-demo docker.io/mongo mongosh
 
 ## Usage
 
-Insert record into MongoDB collection; you can also do it twice or more.
+Insert a record into a MongoDB collection; you can repeat this step as needed.
 ```shell
 mongosh --host mongodb --eval 'db.testdrive.insert({"temperature": 42.84, "humidity": 83.1})'
 ```
@@ -82,18 +82,14 @@ Inspect data stored in CrateDB.
 crash --hosts cratedb -c "SELECT * FROM doc.testdrive"
 ```
 
-::::{todo}
 
-Import data to MongoDB:
-:::{code} shell
+:::{tip}
+To bulk import example data into the same database and collection used above:
+```shell
 mongoimport --db testdrive --collection demo --file demodata.json --jsonArray
+```
+Note: `mongoimport` is part of the [MongoDB Database tools].
 :::
-
-:::{note}
-`mongoimport` is part of the [MongoDB Database tools].
-:::
-
-::::
 
 
 [CrateDB Toolkit MongoDB I/O]: https://cratedb-toolkit.readthedocs.io/io/mongodb/loader.html

--- a/docs/integrate/mongodb/tutorial.md
+++ b/docs/integrate/mongodb/tutorial.md
@@ -1,110 +1,88 @@
 (mongodb-tutorial)=
-(migrating-mongodb)=
-# Import data from MongoDB
+# Load data from MongoDB into CrateDB
 
-In this quick tutorial, you'll use the [CrateDB Toolkit MongoDB I/O subsystem]
-to import data from [MongoDB] into [CrateDB].
+The tutorial will walk you through starting MongoDB and CrateDB,
+inserting a record into a MongoDB collection, transferring the collection
+into a CrateDB table, and validating that the data has
+been stored successfully.
+The data transfer is supported by the [CrateDB Toolkit MongoDB I/O] data
+pipeline elements.
 
-:::{note}
-**Important:** The tutorial uses adapter software which is currently in beta testing.
-If you discover any issues, please [report them] back to us.
-:::
+## Prerequisites
 
-## Synopsis
-Transfer data from MongoDB database/collection into CrateDB schema/table.
-:::{code} shell
-ctk load table \
-  "mongodb+srv://admin:p..d@cluster0.nttj7.mongodb.net/testdrive/demo" \
-  --cratedb-sqlalchemy-url='crate://admin:p..d@gray-wicket-systri-warrick.aks1.westeurope.azure.cratedb.net:4200/testdrive/demo?ssl=true'
-:::
+Docker is used for running all components. This approach works consistently
+across Linux, macOS, and Windows. Alternatively, you can use Podman.
 
-Query data in CrateDB.
-:::{code} shell
-export CRATEPW=password
-crash --host=cratedb.example.org --username=user --command="SELECT * FROM testdrive.demo;"
-:::
-
-## Data Model
-
-MongoDB stores data in collections and documents. CrateDB stores
-data in schemas and tables.
-
-- A **database** in MongoDB is a physical container for collections, similar 
-  to a schema in CrateDB, which groups tables together within a database.
-- A **collection** in MongoDB is a grouping of documents, similar to a table 
-  in CrateDB, which is a structured collection of rows.
-- A **document** in MongoDB is a record in a collection, similar to a row in 
-  a CrateDB table. It is a set of key-value pairs, where each key represents
-  a field, and the value represents the data.
-- A **field** in MongoDB is similar to a column in a CrateDB table. In both
-  systems, fields (or columns) define the attributes for the records
-  (or rows/documents).
-- A **primary key** in MongoDB is typically the _id field, which uniquely 
-  identifies a document within a collection. In CrateDB, a primary key 
-  uniquely identifies a row in a table.
-- An **index** in MongoDB is similar to an index in CrateDB. Both are used to
-  improve query performance by providing a fast lookup for fields (or columns)
-  within documents (or rows).
-
--- [Databases and Collections]
-
-## Tutorial
-
-The tutorial heavily uses Docker to provide services and to run jobs.
-Alternatively, you can use the drop-in replacement Podman.
-The walkthrough uses basic example setup including MongoDB v7.0.x, CrateDB
-and a few samples worth of data that is being transferred to CrateDB.
-
-### Services
-
-Prerequisites are running instances of CrateDB and MongoDB.
-
-Start MongoDB.
-:::{code} shell
-docker run --rm -it --name=mongodb \
-  --publish=27017:27017 \
-  --volume="$PWD/var/lib/mongodb:/data/db" \
-  mongo:latest
-:::
+Create a shared network.
+```shell
+docker network create cratedb-demo
+```
 
 Start CrateDB.
-:::{code} shell
-docker run --rm -it --name=cratedb \
-  --publish=4200:4200 \
-  --volume="$PWD/var/lib/cratedb:/data" \
-  crate:latest -Cdiscovery.type=single-node
+```shell
+docker run --rm --name=cratedb --network=cratedb-demo \
+  --publish=4200:4200 --publish=5432:5432 \
+  --env=CRATE_HEAP_SIZE=2g docker.io/crate -Cdiscovery.type=single-node
+```
+
+Start MongoDB.
+```shell
+docker run --rm --name=mongodb --network=cratedb-demo \
+  --publish=27017:27017 \
+  docker.io/mongo
+```
+
+Prepare shortcuts for the CrateDB shell, CrateDB Toolkit, and the MongoDB client
+programs.
+
+::::{tab-set}
+
+:::{tab-item} Linux and macOS
+To make the settings persistent, add them to your Shell profile (`~/.profile`).
+```shell
+alias crash="docker run --rm -it --network=cratedb-demo ghcr.io/crate/cratedb-toolkit crash"
+alias ctk="docker run --rm -i --network=cratedb-demo ghcr.io/crate/cratedb-toolkit ctk"
+alias mongosh="docker run --rm -i --network=cratedb-demo docker.io/mongo mongosh"
+```
+:::
+:::{tab-item} Windows PowerShell
+To make the settings persistent, add them to your PowerShell profile (`$PROFILE`).
+```powershell
+function crash { docker run --rm -it --network=cratedb-demo ghcr.io/crate/cratedb-toolkit crash @args }
+function ctk { docker run --rm -i --network=cratedb-demo ghcr.io/crate/cratedb-toolkit ctk @args }
+function mongosh { docker run --rm -i --network=cratedb-demo docker.io/mongo mongosh @args }
+```
+:::
+:::{tab-item} Windows Command
+```shell
+doskey crash=docker run --rm -it --network=cratedb-demo ghcr.io/crate/cratedb-toolkit crash $*
+doskey ctk=docker run --rm -i --network=cratedb-demo ghcr.io/crate/cratedb-toolkit ctk $*
+doskey mongosh=docker run --rm -i --network=cratedb-demo docker.io/mongo mongosh $*
+```
 :::
 
-### Sample Data
+::::
 
-In this case we imported demo data to MongoDB in JSON format:
+## Usage
 
-:::{code} shell
-  [
-      {
-          "_id": "66bb0bd8e17c5c509fbc8b2c",
-          "VendorID": 2,
-          "tpep_pickup_datetime": 1563051934000,
-          "tpep_dropoff_datetime": 1563053222000,
-          "passenger_count": 2,
-          "trip_distance": 3.29,
-          "RatecodeID": 1,
-          "store_and_fwd_flag": "N",
-          "PULocationID": 79,
-          "DOLocationID": 170,
-          "payment_type": 1,
-          "fare_amount": 15.5,
-          "extra": 0.5,
-          "mta_tax": 0.5,
-          "tip_amount": 3.86,
-          "tolls_amount": 0,
-          "improvement_surcharge": 0.3,
-          "total_amount": 23.16,
-          "congestion_surcharge": 2.5,
-          "airport_fee": ""
-      }, ...
-  ]
-:::
+Insert record into MongoDB collection; you can also do it twice or more.
+```shell
+mongosh --host mongodb --eval 'db.testdrive.insert({"temperature": 42.84, "humidity": 83.1})'
+```
+
+Invoke the data transfer pipeline.
+```shell
+ctk load table \
+  "mongodb://mongodb/test/testdrive" \
+  --cluster-url="crate://cratedb/doc/testdrive"
+```
+
+Inspect data stored in CrateDB.
+```shell
+crash --hosts cratedb -c "SELECT * FROM doc.testdrive"
+```
+
+::::{todo}
 
 Import data to MongoDB:
 :::{code} shell
@@ -115,99 +93,8 @@ mongoimport --db testdrive --collection demo --file demodata.json --jsonArray
 `mongoimport` is part of the [MongoDB Database tools].
 :::
 
-Verify data is present:
-:::{code} shell
-docker exec -it mongodb mongosh
-:::
-
-:::{code} shell
-use testdrive
-db.demo.find().pretty()
-:::
-
-### Data Import
-
-First, create these command aliases, for better UX.
-:::{code} shell
-alias crash="docker run --rm -it --link=cratedb ghcr.io/crate-workbench/cratedb-toolkit:latest crash"
-alias ctk="docker run --rm -it ghcr.io/crate/cratedb-toolkit:latest  ctk"
-:::
-
-Now, import data from MongoDB database/collection into CrateDB schema/table.
-:::{code} shell
-ctk load table \
-  "mongodb://localhost:27017/testdrive/demo" \
-  --cratedb-sqlalchemy-url="crate://crate@cratedb:4200/testdrive/demo"
-:::
-
-Verify that relevant data has been transferred to CrateDB.
-:::{code} shell
-crash --host=cratedb --command="SELECT * FROM testdrive.demo;"
-:::
-
-## Cloud to Cloud
-
-The procedure for importing data from [MongoDB Atlas] into [CrateDB Cloud] is
-similar, with a few small adjustments.
-
-First, helpful aliases again:
-:::{code} shell
-alias ctk="docker run --rm -it ghcr.io/crate/cratedb-toolkit:latest ctk"
-alias crash="docker run --rm -it ghcr.io/crate-workbench/cratedb-toolkit:latest crash"
-:::
-
-You will need your credentials for both CrateDB and MongoDB. 
-These are, with examples:
-
-**CrateDB Cloud**
-* Host: ```gray-wicket-systri-warrick.aks1.westeurope.azure.cratedb.net```
-* Username: ```admin```
-* Password: ```-9..nn```
-
-**MongoDB Atlas**
-  * Host: ```cluster0.nttj7.mongodb.net```
-  * User: ```admin```
-  * Password: ```a1..d1```
-
-For CrateDB, the credentials are displayed at time of cluster creation.
-For MongoDB, they can be found in the [cloud platform] itself.
-
-Now, same as before, import data from MongoDB database/collection into 
-CrateDB schema/table.
-:::{code} shell
-ctk load table \
-  "mongodb+srv://admin:a..1@cluster0.nttj7.mongodb.net/testdrive/demo" \
-  --cratedb-sqlalchemy-url='crate://admin:-..n@gray-wicket-systri-warrick.aks1.westeurope.azure.cratedb.net:4200/testdrive/demo?ssl=true'
-:::
-
-::: {note}
-Note the **necessary** `ssl=true` query parameter at the end of both database connection URLs
-when working on Cloud-to-Cloud transfers.
-:::
-
-Verify that relevant data has been transferred to CrateDB.
-:::{code} shell
-crash --hosts 'https://admin:-..n@gray-wicket-systri-warrick.aks1.westeurope.azure.cratedb.net:4200' --command 'SELECT * FROM testdrive.demo;'
-:::
-
-## More information
-
-There are more ways to apply the I/O subsystem of CrateDB Toolkit as
-pipeline elements in your daily data operations routines. Please visit the 
-[CrateDB Toolkit MongoDB I/O subsystem] documentation, to learn more about what's possible.
-
-The MongoDB I/O subsystem is based on the [migr8] migration utility package. Please also
-check its documentation to learn about more of its capabilities, supporting
-you when working with MongoDB.
+::::
 
 
-[cloud platform]: https://cloud.mongodb.com
-[CrateDB]: https://github.com/crate/crate
-[CrateDB Cloud]: https://console.cratedb.cloud/
-[CrateDB Toolkit MongoDB I/O subsystem]: https://cratedb-toolkit.readthedocs.io/io/mongodb/loader.html
-[Databases and Collections]: https://www.mongodb.com/docs/manual/core/databases-and-collections/
-[migr8]: https://cratedb-toolkit.readthedocs.io/io/mongodb/migr8.html
-[MongoDB]: https://www.mongodb.com/docs/manual/tutorial/install-mongodb-community-with-docker/
-[MongoDB Atlas]: https://www.mongodb.com/cloud/atlas
+[CrateDB Toolkit MongoDB I/O]: https://cratedb-toolkit.readthedocs.io/io/mongodb/loader.html
 [MongoDB Database tools]: https://www.mongodb.com/docs/database-tools/installation/installation-linux/
-[report them]: https://github.com/crate-workbench/cratedb-toolkit/issues


### PR DESCRIPTION
## About
The goal is to present concise walkthroughs without many bells and whistles, which get to the point of getting you started quickly.

## Details
The content now uses the established template for the starter tutorial in `tutorial.md`. What's different here is that the backbone section also includes two separate files now, one educating about MongoDB's data model, and the other one specifically educating about usage in Cloud environments.

## Preview
https://cratedb-guide--254.org.readthedocs.build/integrate/mongodb/tutorial.html
https://cratedb-guide--254.org.readthedocs.build/integrate/mongodb/
