### PR TITLE
Integrate/InfluxDB: Simplify starter tutorial

### DIFF
--- a/docs/integrate/influxdb/cloud.md
+++ b/docs/integrate/influxdb/cloud.md
@@ -4,25 +4,26 @@ The procedure for importing data from [InfluxDB Cloud] into [CrateDB Cloud] is
 similar, with a few small adjustments.
 
 First, helpful aliases again:
-:::{code} shell
+```shell
 alias ctk="docker run --rm -it ghcr.io/crate/cratedb-toolkit:latest ctk"
 alias crash="docker run --rm -it ghcr.io/crate/cratedb-toolkit:latest crash"
-:::
+```
 
-You will need your credentials for both CrateDB and InfluxDB. 
-These are, with examples:
+You will need your credentials for both CrateDB and InfluxDB.
+Use placeholders and/or environment variables (recommended) to avoid leaking
+secrets in shell history.
 
 :::{rubric} CrateDB Cloud
 :::
-- Host: `purple-shaak-ti.eks1.eu-west-1.aws.cratedb.net`
-- Username: `admin`
-- Password: `dZ..qB`
+- Host: `<CRATEDB_HOST>` (e.g., `cluster-id.eks1.eu-west-1.aws.cratedb.net`)
+- Username: `<CRATEDB_USER>` (e.g., `admin`)
+- Password: `<CRATEDB_PASSWORD>`
 
 :::{rubric} InfluxDB Cloud
 :::
-- Host: `eu-central-1-1.aws.cloud2.influxdata.com`
-- Organization ID: `9fafc869a91a3406`
-- All-Access API token: `T2..==`
+- Host: `<INFLUXDB_HOST>` (e.g., `eu-central-1-1.aws.cloud2.influxdata.com`)
+- Organization ID: `<INFLUXDB_ORG_ID>`
+- All-Access API token: `<INFLUXDB_TOKEN>`
 
 For CrateDB, the credentials are displayed at time of cluster creation.
 For InfluxDB, they can be found in the [cloud platform] itself.
@@ -32,8 +33,8 @@ CrateDB schema/table.
 ```shell
 export CRATEPW='dZ..qB'
 ctk load table \
-  "influxdb2://9f..06:T2..==@eu-central-1-1.aws.cloud2.influxdata.com/testdrive/demo?ssl=true" \
-  --cratedb-sqlalchemy-url="crate://admin:${CRATEPW}@purple-shaak-ti.eks1.eu-west-1.aws.cratedb.net:4200/testdrive/demo?ssl=true"
+  "influxdb2://${INFLUX_ORG}:${INFLUX_TOKEN}@${INFLUX_HOST}/testdrive/demo?ssl=true" \
+  --cluster-url="crate://${CRATEDB_USER}:${CRATEDB_PASSWORD}@${CRATEDB_HOST}:4200/testdrive/demo?ssl=true"
 ```
 
 :::{note}
@@ -44,7 +45,7 @@ when working on Cloud-to-Cloud transfers.
 Verify that relevant data has been transferred to CrateDB.
 ```shell
 export CRATEPW='dZ..qB'
-crash --hosts 'https://admin:${CRATEPW}@purple-shaak-ti.eks1.eu-west-1.aws.cratedb.net:4200' --command 'SELECT * FROM testdrive.demo;'
+crash --hosts "https://${CRATEDB_USER}:${CRATEDB_PASSWORD}@${CRATEDB_HOST}:4200" --command 'SELECT * FROM testdrive.demo;'
 ```
 
 

--- a/docs/integrate/influxdb/cloud.md
+++ b/docs/integrate/influxdb/cloud.md
@@ -1,0 +1,53 @@
+# Cloud to Cloud
+
+The procedure for importing data from [InfluxDB Cloud] into [CrateDB Cloud] is
+similar, with a few small adjustments.
+
+First, helpful aliases again:
+:::{code} shell
+alias ctk="docker run --rm -it ghcr.io/crate/cratedb-toolkit:latest ctk"
+alias crash="docker run --rm -it ghcr.io/crate/cratedb-toolkit:latest crash"
+:::
+
+You will need your credentials for both CrateDB and InfluxDB. 
+These are, with examples:
+
+:::{rubric} CrateDB Cloud
+:::
+- Host: `purple-shaak-ti.eks1.eu-west-1.aws.cratedb.net`
+- Username: `admin`
+- Password: `dZ..qB`
+
+:::{rubric} InfluxDB Cloud
+:::
+- Host: `eu-central-1-1.aws.cloud2.influxdata.com`
+- Organization ID: `9fafc869a91a3406`
+- All-Access API token: `T2..==`
+
+For CrateDB, the credentials are displayed at time of cluster creation.
+For InfluxDB, they can be found in the [cloud platform] itself.
+
+Now, same as before, import data from InfluxDB bucket/measurement into 
+CrateDB schema/table.
+```shell
+export CRATEPW='dZ..qB'
+ctk load table \
+  "influxdb2://9f..06:T2..==@eu-central-1-1.aws.cloud2.influxdata.com/testdrive/demo?ssl=true" \
+  --cratedb-sqlalchemy-url="crate://admin:${CRATEPW}@purple-shaak-ti.eks1.eu-west-1.aws.cratedb.net:4200/testdrive/demo?ssl=true"
+```
+
+:::{note}
+Note the **necessary** `ssl=true` query parameter at the end of both database connection URLs
+when working on Cloud-to-Cloud transfers.
+:::
+
+Verify that relevant data has been transferred to CrateDB.
+```shell
+export CRATEPW='dZ..qB'
+crash --hosts 'https://admin:${CRATEPW}@purple-shaak-ti.eks1.eu-west-1.aws.cratedb.net:4200' --command 'SELECT * FROM testdrive.demo;'
+```
+
+
+[cloud platform]: https://docs.influxdata.com/influxdb/cloud/admin
+[CrateDB Cloud]: https://console.cratedb.cloud/
+[InfluxDB Cloud]: https://cloud2.influxdata.com/

--- a/docs/integrate/influxdb/cloud.md
+++ b/docs/integrate/influxdb/cloud.md
@@ -1,7 +1,7 @@
 # Cloud to Cloud
 
 The procedure for importing data from [InfluxDB Cloud] into [CrateDB Cloud] is
-similar like the {ref}`standalone variant <influxdb-tutorial>`, with a few small
+similar to the {ref}`standalone variant <influxdb-tutorial>`, with a few small
 adjustments.
 
 First, helpful aliases:
@@ -32,7 +32,6 @@ For InfluxDB, they can be found in the [cloud platform] itself.
 Now, same as before, import data from InfluxDB bucket/measurement into 
 CrateDB schema/table.
 ```shell
-export CRATEPW='dZ..qB'
 ctk load table \
   "influxdb2://${INFLUX_ORG}:${INFLUX_TOKEN}@${INFLUX_HOST}/testdrive/demo?ssl=true" \
   --cluster-url="crate://${CRATEDB_USER}:${CRATEDB_PASSWORD}@${CRATEDB_HOST}:4200/testdrive/demo?ssl=true"
@@ -45,7 +44,6 @@ when working on Cloud-to-Cloud transfers.
 
 Verify that relevant data has been transferred to CrateDB.
 ```shell
-export CRATEPW='dZ..qB'
 crash --hosts "https://${CRATEDB_USER}:${CRATEDB_PASSWORD}@${CRATEDB_HOST}:4200" --command 'SELECT * FROM testdrive.demo;'
 ```
 

--- a/docs/integrate/influxdb/cloud.md
+++ b/docs/integrate/influxdb/cloud.md
@@ -1,15 +1,16 @@
 # Cloud to Cloud
 
 The procedure for importing data from [InfluxDB Cloud] into [CrateDB Cloud] is
-similar, with a few small adjustments.
+similar like the {ref}`standalone variant <influxdb-tutorial>`, with a few small
+adjustments.
 
-First, helpful aliases again:
+First, helpful aliases:
 ```shell
 alias ctk="docker run --rm -it ghcr.io/crate/cratedb-toolkit:latest ctk"
 alias crash="docker run --rm -it ghcr.io/crate/cratedb-toolkit:latest crash"
 ```
 
-You will need your credentials for both CrateDB and InfluxDB.
+You will need credentials for both CrateDB and InfluxDB.
 Use placeholders and/or environment variables (recommended) to avoid leaking
 secrets in shell history.
 

--- a/docs/integrate/influxdb/index.md
+++ b/docs/integrate/influxdb/index.md
@@ -62,4 +62,15 @@ Load InfluxDB collections into CrateDB.
 :maxdepth: 1
 :hidden:
 Tutorial <tutorial>
+cloud
+model
 :::
+
+
+:::{note}
+The InfluxDB I/O subsystem is based on the [influxio] package. See its
+documentation for additional capabilities when working with InfluxDB.
+:::
+
+
+[influxio]: https://influxio.readthedocs.io/

--- a/docs/integrate/influxdb/index.md
+++ b/docs/integrate/influxdb/index.md
@@ -30,7 +30,7 @@ fast query response times to build user interfaces, monitoring, and automation s
 ```shell
 ctk load table \
   "influxdb2://example:token@influxdb.example.org:8086/testdrive/demo" \
-  --cratedb-sqlalchemy-url="crate://user:password@cratedb.example.org:4200/testdrive/demo"
+  --cluster-url="crate://user:password@cratedb.example.org:4200/testdrive/demo"
 ```
 
 That's the blueprint for the InfluxDB URI:

--- a/docs/integrate/influxdb/model.md
+++ b/docs/integrate/influxdb/model.md
@@ -1,6 +1,7 @@
+(influxdb-data-model)=
 # Data Model
 
-InfluxDB stores time series data in buckets and measurements. CrateDB stores
+InfluxDB stores time-series data in buckets and measurements; CrateDB stores
 data in schemas and tables.
 
 - A **bucket** is a named location with a retention policy where time series data is stored.
@@ -10,7 +11,7 @@ data in schemas and tables.
 - A **field** is similar to a non-indexed column in an SQL database.
 - A **point** is similar to an SQL row.
 
-> via: [What are series and bucket in InfluxDB]
+> Source: [What are series and bucket in InfluxDB]
 
 
 [What are series and bucket in InfluxDB]: https://stackoverflow.com/questions/58190272/what-are-series-and-bucket-in-influxdb/69951376#69951376

--- a/docs/integrate/influxdb/model.md
+++ b/docs/integrate/influxdb/model.md
@@ -1,0 +1,16 @@
+# Data Model
+
+InfluxDB stores time series data in buckets and measurements. CrateDB stores
+data in schemas and tables.
+
+- A **bucket** is a named location with a retention policy where time series data is stored.
+- A **series** is a logical grouping of data defined by shared measurement, tag, and field.
+- A **measurement** is similar to an SQL database table.
+- A **tag** is similar to an indexed column in an SQL database.
+- A **field** is similar to an un-indexed column in an SQL database.
+- A **point** is similar to an SQL row.
+
+> via: [What are series and bucket in InfluxDB]
+
+
+[What are series and bucket in InfluxDB]: https://stackoverflow.com/questions/58190272/what-are-series-and-bucket-in-influxdb/69951376#69951376

--- a/docs/integrate/influxdb/model.md
+++ b/docs/integrate/influxdb/model.md
@@ -4,10 +4,10 @@ InfluxDB stores time series data in buckets and measurements. CrateDB stores
 data in schemas and tables.
 
 - A **bucket** is a named location with a retention policy where time series data is stored.
-- A **series** is a logical grouping of data defined by shared measurement, tag, and field.
+- A **series** is a logical grouping of data defined by a shared measurement and tag set (fields do not define series).
 - A **measurement** is similar to an SQL database table.
 - A **tag** is similar to an indexed column in an SQL database.
-- A **field** is similar to an un-indexed column in an SQL database.
+- A **field** is similar to a non-indexed column in an SQL database.
 - A **point** is similar to an SQL row.
 
 > via: [What are series and bucket in InfluxDB]

--- a/docs/integrate/influxdb/tutorial.md
+++ b/docs/integrate/influxdb/tutorial.md
@@ -12,7 +12,7 @@ Transfer data from InfluxDB bucket/measurement into CrateDB schema/table.
 ```shell
 ctk load table \
   "influxdb2://example:token@influxdb.example.org:8086/testdrive/demo" \
-  --cratedb-sqlalchemy-url="crate://user:password@cratedb.example.org:4200/testdrive/demo"
+  --cluster-url="crate://user:password@cratedb.example.org:4200/testdrive/demo"
 ```
 Query data in CrateDB.
 ```shell
@@ -25,7 +25,7 @@ Transfer data from InfluxDB line protocol file into CrateDB schema/table.
 ```shell
 ctk load table \
   "https://github.com/influxdata/influxdb2-sample-data/raw/master/air-sensor-data/air-sensor-data.lp" \
-  --cratedb-sqlalchemy-url="crate://user:password@cratedb.example.org:4200/testdrive/air-sensor-data"
+  --cluster-url="crate://user:password@cratedb.example.org:4200/testdrive/air-sensor-data"
 ```
 Query data in CrateDB.
 ```shell
@@ -100,7 +100,7 @@ doskey influx-write=influx write --bucket=testdrive --org=example --token=token 
 
 ## Usage
 
-Write a few samples worth of data to InfluxDB.
+Write a few sample records to InfluxDB.
 ```shell
 influx-write "demo,region=amazonas temperature=27.4,humidity=92.3,windspeed=4.5 1588363200"
 influx-write "demo,region=amazonas temperature=28.2,humidity=88.7,windspeed=4.7 1588549600"

--- a/docs/integrate/influxdb/tutorial.md
+++ b/docs/integrate/influxdb/tutorial.md
@@ -33,35 +33,27 @@ export CRATEPW=password
 crash --host=cratedb.example.org --username=user --command='SELECT * FROM testdrive."air-sensor-data";'
 ```
 
+## Prerequisites
 
-## Data Model
+Docker is used for running all components. This approach works consistently
+across Linux, macOS, and Windows. Alternatively, you can use Podman.
 
-InfluxDB stores time series data in buckets and measurements. CrateDB stores
-data in schemas and tables.
+Create a shared network.
+```shell
+docker network create cratedb-demo
+```
 
-- A **bucket** is a named location with a retention policy where time series data is stored.
-- A **series** is a logical grouping of data defined by shared measurement, tag, and field.
-- A **measurement** is similar to an SQL database table.
-- A **tag** is similar to an indexed column in an SQL database.
-- A **field** is similar to an un-indexed column in an SQL database.
-- A **point** is similar to an SQL row.
-
-> via: [What are series and bucket in InfluxDB]
-
-## Tutorial
-
-The tutorial heavily uses Docker to provide services and to run jobs.
-Alternatively, you can use the drop-in replacement Podman.
-The walkthrough uses basic example setup including InfluxDB 2.x and
-a few samples worth of data that is being transferred to CrateDB.
-
-### Services
-
-Prerequisites are running instances of CrateDB and InfluxDB.
+Start CrateDB.
+```shell
+docker run --rm --name=cratedb --network=cratedb-demo \
+  --publish=4200:4200 \
+  --volume="$PWD/var/lib/cratedb:/data" \
+  docker.io/crate -Cdiscovery.type=single-node
+```
 
 Start InfluxDB.
-:::{code} shell
-docker run --rm -it --name=influxdb \
+```shell
+docker run --rm --name=influxdb --network=cratedb-demo \
   --publish=8086:8086 \
   --env=DOCKER_INFLUXDB_INIT_MODE=setup \
   --env=DOCKER_INFLUXDB_INIT_USERNAME=admin \
@@ -69,124 +61,68 @@ docker run --rm -it --name=influxdb \
   --env=DOCKER_INFLUXDB_INIT_ORG=example \
   --env=DOCKER_INFLUXDB_INIT_BUCKET=testdrive \
   --env=DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=token \
-  --volume="$PWD/var/lib/influxdb2:/var/lib/influxdb2" \
-  influxdb:2
-:::
+  docker.io/influxdb:2
+```
 
-Start CrateDB.
-:::{code} shell
-docker run --rm -it --name=cratedb \
-  --publish=4200:4200 \
-  --volume="$PWD/var/lib/cratedb:/data" \
-  crate:latest -Cdiscovery.type=single-node
-:::
+Prepare shortcuts for the CrateDB shell, CrateDB Toolkit, and the InfluxDB client
+programs.
 
-### Sample Data
-Command shortcuts. 
-:::{code} shell
+::::{tab-set}
+
+:::{tab-item} Linux and macOS
+To make the settings persistent, add them to your shell profile (`~/.profile`).
+```shell
+alias crash="docker run --rm -it --network=cratedb-demo ghcr.io/crate/cratedb-toolkit crash"
+alias ctk="docker run --rm -i --network=cratedb-demo ghcr.io/crate/cratedb-toolkit ctk"
 alias influx="docker exec influxdb influx"
 alias influx-write="influx write --bucket=testdrive --org=example --token=token --precision=s"
+```
+:::
+:::{tab-item} Windows PowerShell
+To make the settings persistent, add them to your PowerShell profile (`$PROFILE`).
+```powershell
+function crash { docker run --rm -it --network=cratedb-demo ghcr.io/crate/cratedb-toolkit crash @args }
+function ctk { docker run --rm -i --network=cratedb-demo ghcr.io/crate/cratedb-toolkit ctk @args }
+function influx { docker exec influxdb influx @args }
+function influx-write { influx write --bucket=testdrive --org=example --token=token --precision=s @args }
+```
+:::
+:::{tab-item} Windows Command
+```shell
+doskey crash=docker run --rm -it --network=cratedb-demo ghcr.io/crate/cratedb-toolkit crash $*
+doskey ctk=docker run --rm -i --network=cratedb-demo ghcr.io/crate/cratedb-toolkit ctk $*
+doskey influx=docker exec influxdb influx $*
+doskey influx-write=influx write --bucket=testdrive --org=example --token=token --precision=s $*
+```
 :::
 
+::::
+
+## Usage
+
 Write a few samples worth of data to InfluxDB.
-:::{code} shell
+```shell
 influx-write "demo,region=amazonas temperature=27.4,humidity=92.3,windspeed=4.5 1588363200"
 influx-write "demo,region=amazonas temperature=28.2,humidity=88.7,windspeed=4.7 1588549600"
 influx-write "demo,region=amazonas temperature=27.9,humidity=91.6,windspeed=3.2 1588736000"
 influx-write "demo,region=amazonas temperature=29.1,humidity=88.1,windspeed=2.4 1588922400"
 influx-write "demo,region=amazonas temperature=28.6,humidity=93.4,windspeed=2.9 1589108800"
-:::
+```
 
-### Data Import
-
-First, create these command aliases, for better UX.
-:::{code} shell
-alias crash="docker run --rm -it --link=cratedb ghcr.io/crate/cratedb-toolkit:latest crash"
-alias ctk="docker run --rm -it --link=cratedb --link=influxdb ghcr.io/crate/cratedb-toolkit:latest ctk"
-:::
-
-Now, import data from InfluxDB bucket/measurement into CrateDB schema/table.
-:::{code} shell
+Invoke the data transfer pipeline, importing data from
+InfluxDB bucket/measurement into CrateDB schema/table.
+```shell
 ctk load table \
   "influxdb2://example:token@influxdb:8086/testdrive/demo" \
-  --cratedb-sqlalchemy-url="crate://crate@cratedb:4200/testdrive/demo"
-:::
+  --cluster-url="crate://crate@cratedb:4200/doc/testdrive"
+```
 
-Verify that relevant data has been transferred to CrateDB.
-:::{code} shell
-crash --host=cratedb --command="SELECT * FROM testdrive.demo;"
-:::
-
-## Cloud to Cloud
-
-The procedure for importing data from [InfluxDB Cloud] into [CrateDB Cloud] is
-similar, with a few small adjustments.
-
-First, helpful aliases again:
-:::{code} shell
-alias ctk="docker run --rm -it ghcr.io/crate/cratedb-toolkit:latest ctk"
-alias crash="docker run --rm -it ghcr.io/crate/cratedb-toolkit:latest crash"
-:::
-
-You will need your credentials for both CrateDB and InfluxDB. 
-These are, with examples:
-
-:::{rubric} CrateDB Cloud
-:::
-- Host: ```purple-shaak-ti.eks1.eu-west-1.aws.cratedb.net```
-- Username: ```admin```
-- Password: ```dZ..qB```
-
-:::{rubric} InfluxDB Cloud
-:::
-- Host: ```eu-central-1-1.aws.cloud2.influxdata.com```
-- Organization ID: ```9fafc869a91a3406```
-- All-Access API token: ```T2..==```
-
-For CrateDB, the credentials are displayed at time of cluster creation.
-For InfluxDB, they can be found in the [cloud platform] itself.
-
-Now, same as before, import data from InfluxDB bucket/measurement into 
-CrateDB schema/table.
-:::{code} shell
-export CRATEPW='dZ..qB'
-ctk load table \
-  "influxdb2://9f..06:T2..==@eu-central-1-1.aws.cloud2.influxdata.com/testdrive/demo?ssl=true" \
-  --cratedb-sqlalchemy-url="crate://admin:${CRATEPW}@purple-shaak-ti.eks1.eu-west-1.aws.cratedb.net:4200/testdrive/demo?ssl=true"
-:::
-
-::: {note}
-Note the **necessary** `ssl=true` query parameter at the end of both database connection URLs
-when working on Cloud-to-Cloud transfers.
-:::
-
-Verify that relevant data has been transferred to CrateDB.
-:::{code} shell
-export CRATEPW='dZ..qB'
-crash --hosts 'https://admin:${CRATEPW}@purple-shaak-ti.eks1.eu-west-1.aws.cratedb.net:4200' --command 'SELECT * FROM testdrive.demo;'
-:::
-
-## More information
-
-There are more ways to apply the I/O subsystem of CrateDB Toolkit as
-pipeline elements in your daily data operations routines. Please visit the 
-[CrateDB Toolkit InfluxDB I/O subsystem] documentation, to learn more about what's possible.
-
-The InfluxDB I/O subsystem is based on the [influxio] package. See its
-documentation for additional capabilities when working with InfluxDB.
-
-:::{note}
-**Important:** If you discover any issues with this adapter, please
-[report them] back to us.
-:::
+Inspect data stored in CrateDB.
+```shell
+crash --hosts cratedb -c "SELECT * FROM doc.testdrive"
+```
 
 
-[cloud platform]: https://docs.influxdata.com/influxdb/cloud/admin
 [CrateDB]: https://github.com/crate/crate
-[CrateDB Cloud]: https://console.cratedb.cloud/
 [CrateDB Toolkit InfluxDB I/O subsystem]: https://cratedb-toolkit.readthedocs.io/io/influxdb/loader.html
 [InfluxDB]: https://github.com/influxdata/influxdb
-[InfluxDB Cloud]: https://cloud2.influxdata.com/
-[influxio]: https://influxio.readthedocs.io/
-[report them]: https://github.com/crate/cratedb-toolkit/issues
-[What are series and bucket in InfluxDB]: https://stackoverflow.com/questions/58190272/what-are-series-and-bucket-in-influxdb/69951376#69951376


### PR DESCRIPTION
## About
The goal is to present concise walkthroughs without many bells and whistles, which get to the point of getting you started quickly.

## Details
The content now uses the established template for the starter tutorial in `tutorial.md`. What's different here is that the backbone section also includes two separate files now, one educating about InfluxDB's data model, and the other one specifically educating about usage in Cloud environments.

## Preview
https://cratedb-guide--255.org.readthedocs.build/integrate/influxdb/tutorial.html
