### PR TITLE
Integrate/PostgreSQL: Add section with starter tutorial

### DIFF
--- a/docs/integrate/index.md
+++ b/docs/integrate/index.md
@@ -51,6 +51,7 @@ n8n/index
 nifi/index
 node-red/index
 plotly/index
+postgresql/index
 Power BI <powerbi/index>
 prometheus/index
 pyviz/index

--- a/docs/integrate/postgresql/index.md
+++ b/docs/integrate/postgresql/index.md
@@ -1,0 +1,45 @@
+(postgresql)=
+# PostgreSQL
+
+```{div} .float-right
+[![postgresql-logo](https://www.postgresql.org/media/img/about/press/elephant.png){height=60px loading=lazy}][PostgreSQL]
+```
+```{div} .clearfix
+```
+
+:::{rubric} About
+:::
+
+[PostgreSQL] is the world's most advanced open source relational database.
+
+:::{rubric} Synopsis
+:::
+
+```shell
+uvx 'cratedb-toolkit[io-ingestr]' load table \
+  "postgresql://<username>:<password>@host:port/dbname?table=demo" \
+  --cluster-url="crate://crate:crate@localhost:4200/testdrive/postgresql_demo"
+```
+
+:::{rubric} Learn
+:::
+
+::::{grid}
+
+:::{grid-item-card} Tutorial: Use CrateDB Toolkit
+:link: postgresql-tutorial
+:link-type: ref
+Load data from PostgreSQL into CrateDB using CrateDB Toolkit.
+:::
+
+::::
+
+
+:::{toctree}
+:maxdepth: 1
+:hidden:
+Tutorial <tutorial>
+:::
+
+
+[PostgreSQL]: https://www.postgresql.org/

--- a/docs/integrate/postgresql/tutorial.md
+++ b/docs/integrate/postgresql/tutorial.md
@@ -1,0 +1,89 @@
+(postgresql-tutorial)=
+# Load data from PostgreSQL into CrateDB
+
+The tutorial will walk you through starting [PostgreSQL] and CrateDB,
+inserting a record into PostgreSQL, loading data into a CrateDB table,
+and validating that the data has been stored successfully.
+The data transfer is supported by the
+{ref}`CrateDB Toolkit Ingestr I/O <ctk:ingestr>` data pipeline elements.
+
+## Prerequisites
+
+Docker is used for running all components. This approach works consistently
+across Linux, macOS, and Windows. Alternatively, you can use Podman.
+
+Create a shared network.
+```shell
+docker network create cratedb-demo
+```
+
+Start CrateDB.
+```shell
+docker run --rm --name=cratedb --network=cratedb-demo \
+  --publish=4200:4200 --publish=5432:5432 \
+  --env=CRATE_HEAP_SIZE=2g docker.io/crate -Cdiscovery.type=single-node
+```
+
+Start PostgreSQL.
+```shell
+docker run --rm --name=postgresql --network=cratedb-demo \
+  --publish=5433:5432 --env "POSTGRES_HOST_AUTH_METHOD=trust" \
+  docker.io/postgres postgres -c log_statement=all
+```
+
+Prepare shortcuts for the CrateDB shell, CrateDB Toolkit, and the PostgreSQL client
+programs.
+
+::::{tab-set}
+
+:::{tab-item} Linux and macOS
+To make the settings persistent, add them to your shell profile (`~/.profile`).
+```shell
+alias crash="docker run --rm -it --network=cratedb-demo ghcr.io/crate/cratedb-toolkit crash"
+alias ctk="docker run --rm -i --network=cratedb-demo ghcr.io/crate/cratedb-toolkit ctk"
+alias psql="docker run --rm --network=cratedb-demo docker.io/postgres psql"
+```
+:::
+:::{tab-item} Windows PowerShell
+To make the settings persistent, add them to your PowerShell profile (`$PROFILE`).
+```powershell
+function crash { docker run --rm -it --network=cratedb-demo ghcr.io/crate/cratedb-toolkit crash @args }
+function ctk { docker run --rm -i --network=cratedb-demo ghcr.io/crate/cratedb-toolkit ctk @args }
+function psql { docker run --rm -i --network=cratedb-demo docker.io/postgres psql @args }
+```
+:::
+:::{tab-item} Windows Command
+```shell
+doskey crash=docker run --rm -it --network=cratedb-demo ghcr.io/crate/cratedb-toolkit crash $*
+doskey ctk=docker run --rm -i --network=cratedb-demo ghcr.io/crate/cratedb-toolkit ctk $*
+doskey psql=docker run --rm -i --network=cratedb-demo docker.io/postgres psql $*
+```
+:::
+
+::::
+
+## Usage
+
+Write a few sample records to PostgreSQL.
+```shell
+psql "postgresql://postgres:postgres@postgresql:5432/" <<SQL
+CREATE TABLE IF NOT EXISTS demo (id BIGINT, data JSONB);
+INSERT INTO demo (id, data) VALUES (1, '{"temperature": 42.84, "humidity": 83.1}');
+INSERT INTO demo (id, data) VALUES (2, '{"temperature": 84.84, "humidity": 56.99}');
+SQL
+```
+
+Invoke the data transfer pipeline.
+```shell
+ctk load table \
+  "postgresql://postgres:postgres@postgresql/public?table=demo" \
+  --cluster-url="crate://crate:crate@cratedb:4200/testdrive/postgresql_demo"
+```
+
+Inspect data stored in CrateDB.
+```shell
+crash --hosts cratedb -c "SELECT * FROM testdrive.postgresql_demo"
+```
+
+
+[PostgreSQL]: https://www.postgresql.org/


### PR DESCRIPTION
## About
There was no section about PostgreSQL yet.

## Details
The goal is to present concise walkthroughs without many bells and
whistles, which get to the point of getting you started quickly.

Use the canonical template to present another data nozzle based on
the CTK Ingestr I/O subsystem.

## Preview
https://cratedb-guide--257.org.readthedocs.build/integrate/postgresql/
