### PR TITLE
Update to `crate-docs-theme>=0.40.0.dev0`

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-crate-docs-theme>=0.38.5
+crate-docs-theme>=0.40.0.dev0
 
 # cache-buster-20240305
 # Remark: Used for PyPI download cache busting on GHA.


### PR DESCRIPTION
## About
Include a few updates to probe here, and a mitigation against recently increased build errors on CI.

## References
- https://github.com/crate/crate-docs-theme/pull/620
- https://github.com/crate/crate-docs-theme/pull/621
- https://github.com/crate/crate-docs-theme/pull/622
