### PR TITLE
Tableau: Usage guide

### DIFF
--- a/docs/integrate/tableau/index.md
+++ b/docs/integrate/tableau/index.md
@@ -26,7 +26,7 @@ data by translating drag-and-drop actions into data queries through an intuitive
 :::{grid-item-card} Blog: Connecting to CrateDB from Tableau with JDBC
 :link: https://cratedb.com/blog/connecting-to-cratedb-from-tableau-with-jdbc
 :link-type: url
-In this tutorial, you will:
+In this usage guide, you will:
 - In CrateDB, create a table and provision the Iris dataset.
 - Set up the PostgreSQL JDBC driver for Tableau.
 - Connect to CrateDB from Tableau using PostgreSQL JDBC.
@@ -34,7 +34,7 @@ In this tutorial, you will:
 :::
 
 :::{grid-item-card} Article: Using CrateDB with Tableau
-:link: tableau-tutorial
+:link: tableau-usage
 :link-type: ref
 How to install the latest PostgreSQL JDBC driver (e.g.
 `postgresql-42.7.1.jar` or newer) for using Tableau.
@@ -65,7 +65,7 @@ We are tracking interoperability issues per [Tool: Tableau] and
 :::{toctree}
 :maxdepth: 1
 :hidden:
-Tutorial <tutorial>
+Usage <usage>
 :::
 
 

--- a/docs/integrate/tableau/usage.md
+++ b/docs/integrate/tableau/usage.md
@@ -1,4 +1,4 @@
-(tableau-tutorial)=
+(tableau-usage)=
 # Using CrateDB with Tableau
 
 For using Tableau with CrateDB, install the latest PostgreSQL driver, as detailed in the steps below.


### PR DESCRIPTION
## About

Continue adding integration guides from the community forum.

## Preview

- https://cratedb-guide--306.org.readthedocs.build/integrate/tableau/usage.html

## References

- GH-102
