### PR TITLE
CrateDB 3.x: Documentation for 3.3 turned off, so refer to sources instead. Also tune down other content.

### DIFF
--- a/docs/admin/clustering/multi-node-setup.md
+++ b/docs/admin/clustering/multi-node-setup.md
@@ -191,7 +191,7 @@ discovers the rest of the cluster via the seed nodes.
 :::{TIP}
 If you are using CrateDB 3.x or below, you can use the
 [discovery.zen.ping.unicast.hosts] setting instead of
-`discovery.seed_hosts`.
+{ref}`crate-reference:discovery.seed_hosts`.
 :::
 
 (unicast-discovery)=
@@ -444,8 +444,8 @@ transport.publish_port: 4321
 [configuration]: https://cratedb.com/docs/crate/reference/en/latest/config/index.html
 [crate_home]: https://cratedb.com/docs/crate/reference/en/latest/config/environment.html#conf-env-crate-home
 [daemon]: https://en.wikipedia.org/wiki/Daemon_(computing)
-[discovery.zen.minimum_master_nodes]: https://cratedb.com/docs/crate/reference/en/3.3/config/cluster.html#discovery-zen-minimum-master-nodes
-[discovery.zen.ping.unicast.hosts]: https://cratedb.com/docs/crate/reference/en/3.3/config/cluster.html#unicast-host-discovery
+[discovery.zen.minimum_master_nodes]: https://github.com/crate/crate/blob/3.3/blackbox/docs/config/cluster.rst#discovery
+[discovery.zen.ping.unicast.hosts]: https://github.com/crate/crate/blob/3.3/blackbox/docs/config/cluster.rst#unicast-host-discovery
 [gateway.expected_data_nodes]: https://cratedb.com/docs/crate/reference/en/latest/config/cluster.html#gateway-expected-data-nodes
 [gateway.recover_after_data_nodes]: https://cratedb.com/docs/crate/reference/en/latest/config/cluster.html#gateway-recover-after-data-nodes
 [hostname]: https://en.wikipedia.org/wiki/Hostname

--- a/docs/admin/clustering/multi-node-setup.md
+++ b/docs/admin/clustering/multi-node-setup.md
@@ -188,11 +188,6 @@ You must configure every node with a list of seed nodes. Each node
 discovers the rest of the cluster via the seed nodes.
 :::
 
-:::{TIP}
-If you are using CrateDB 3.x or below, you can use the
-[discovery.zen.ping.unicast.hosts] setting instead of
-{ref}`crate-reference:discovery.seed_hosts`.
-:::
 
 (unicast-discovery)=
 
@@ -293,11 +288,6 @@ independent clusters (which may result in data loss).
 CrateDB requires a [quorum] of nodes before a master can be elected. A quorum
 ensures that the cluster does not elect multiple masters in the event of a
 network partition (also known as a [split-brain] scenario).
-
-CrateDB (versions 4.x and above) will automatically determine the ideal [quorum
-size][quorum size], but if you are using CrateDB versions 3.x and below, you must manually set
-the quorum size using the [discovery.zen.minimum_master_nodes] setting. For
-a three-node cluster, you must declare all nodes to be master-eligible.
 
 (metadata-gateway)=
 
@@ -431,6 +421,17 @@ transport.publish_port: 4321
 :::{SEEALSO}
 {ref}`More information about port settings <crate-reference:conf_ports>`
 :::
+
+## CrateDB 3.x
+
+CrateDB (versions 4.x and above) will automatically determine the ideal [quorum
+size][quorum size], but if you are using CrateDB versions 3.x and below, you
+must manually set the quorum size using the [discovery.zen.minimum_master_nodes]
+setting. For a three-node cluster, you must declare all nodes to be master-eligible.
+
+If you are using CrateDB 3.x or below, to configure every node with a list of
+seed nodes, you can use the [discovery.zen.ping.unicast.hosts] setting instead
+of {ref}`crate-reference:discovery.seed_hosts`.
 
 
 [127.0.0.1:4200]: http://127.0.0.1:4200/

--- a/docs/admin/clustering/scale/kubernetes.md
+++ b/docs/admin/clustering/scale/kubernetes.md
@@ -121,12 +121,14 @@ because CrateDB must recover and rebalance shards as the nodes drop out.
 :::{NOTE}
 The following only applies to CrateDB versions 3.x and below.
 
-The `discovery.zen.minimum_master_nodes` setting is {ref}`no longer used
-<node-discovery>` in CrateDB versions 4.x and above.
+The [discovery.zen.minimum_master_nodes] setting is no longer used in CrateDB
+versions 4.x and above. Please refer to the current documentation section
+about {ref}`crate-reference:conf_discovery`.
 :::
 
 The [discovery.zen.minimum_master_nodes] setting affects {ref}`metadata
-master <crate-reference:concept-clusters>` election.
+master <crate-reference:concept-clusters>` election with previous versions
+of CrateDB.
 
 This setting can be changed while CrateDB is running, like so:
 
@@ -144,11 +146,11 @@ Changes to the Kubernetes controller configuration can then be deployed using
 Control][using version control].
 
 :::{CAUTION}
-If `discovery.zen.minimum_master_nodes` is set to more than the current
+If [discovery.zen.minimum_master_nodes] is set to more than the current
 number of nodes in the cluster, the cluster will disband. On the other
 hand, a number that is too small might lead to a [split-brain] scenario.
 
-Accordingly, it is important to [adjust this number carefully] when
+Accordingly, it is important to adjust this number carefully when
 scaling CrateDB.
 :::
 
@@ -185,11 +187,11 @@ However, you should only do this on a production cluster if you need to
 scale to handle a load spike quickly.
 :::
 
-[adjust this number carefully]: https://cratedb.com/docs/crate/reference/en/3.3/config/cluster.html#discovery-zen-minimum-master-nodes
+
 [containerization]: https://www.docker.com/resources/what-container
 [cratedb docker image]: https://hub.docker.com/_/crate/
 [deleted and recreated]: https://kubernetes.io/docs/concepts/cluster-administration/manage-deployment/#disruptive-updates
-[discovery.zen.minimum_master_nodes]: https://cratedb.com/docs/crate/reference/en/3.3/config/cluster.html#discovery-zen-minimum-master-nodes
+[discovery.zen.minimum_master_nodes]: https://github.com/crate/crate/blob/3.3/blackbox/docs/config/cluster.rst#discovery
 [docker]: https://www.docker.com/
 [gateway.expected_data_nodes]: https://cratedb.com/docs/crate/reference/en/latest/admin/system-information.html#recovery-expected-data-nodes
 [gateway.recover_after_data_nodes]: https://cratedb.com/docs/crate/reference/en/latest/admin/system-information.html#recovery-after-data-nodes

--- a/docs/admin/clustering/scale/kubernetes.md
+++ b/docs/admin/clustering/scale/kubernetes.md
@@ -126,6 +126,7 @@ versions 4.x and above. Please refer to the current documentation section
 about {ref}`crate-reference:conf_discovery`.
 :::
 
+::::{dropdown} Details about `discovery.zen.minimum_master_nodes` on CrateDB 3.x
 The [discovery.zen.minimum_master_nodes] setting affects {ref}`metadata
 master <crate-reference:concept-clusters>` election with previous versions
 of CrateDB.
@@ -142,8 +143,8 @@ reconfiguration by altering the `discovery.zen.minimum_master_nodes` command
 option.
 
 Changes to the Kubernetes controller configuration can then be deployed using
-`kubectl replace` as shown in the previous subsection, [Using Version
-Control][using version control].
+`kubectl replace` as shown in the previous subsection, {ref}`using version
+control <scaling-kube-vc>`.
 
 :::{CAUTION}
 If [discovery.zen.minimum_master_nodes] is set to more than the current
@@ -153,6 +154,8 @@ hand, a number that is too small might lead to a [split-brain] scenario.
 Accordingly, it is important to adjust this number carefully when
 scaling CrateDB.
 :::
+
+::::
 
 (scaling-kube-recovery)=
 
@@ -175,8 +178,8 @@ reconfiguration by altering the `EXPECTED_NODES` environment variable and the
 `recover_after_data_nodes` command option.
 
 Changes to the Kubernetes controller configuration can then be deployed using
-`kubectl replace` as shown in the previous subsection, [Using Version
-Control][using version control].
+`kubectl replace` as shown in the previous subsection, {ref}`using version
+control <scaling-kube-vc>`.
 
 :::{NOTE}
 You can scale a CrateDB cluster without updating these values, but the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,8 +80,6 @@ linkcheck_ignore += [
     r"https://www.computerhope.com/",
     # Out of service.
     r"https://s3.amazonaws.com/nyc-tlc/.*",
-    # 2025-09-29: Phased out CrateDB 3.3 docs
-    r"https://cratedb.com/docs/crate/reference/en/3.3/",
     # 403 Client Error: Forbidden for url
     r"https://docs.docker.com/",
 ]

--- a/docs/install/cloud/aws/ec2-setup.rst
+++ b/docs/install/cloud/aws/ec2-setup.rst
@@ -199,8 +199,8 @@ See also :ref:`crate-reference:discovery.ec2.availability_zones`.
 .. _3.3: https://cratedb.com/docs/crate/reference/en/3.3/config/cluster.html#discovery
 .. _Amazon EC2: https://aws.amazon.com/ec2/
 .. _assign them with an IAM role: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/attach-iam-role.html
-.. _AWS guide: httsp://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
+.. _AWS guide: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
 .. _EC2 API: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/Welcome.html
 .. _IAM roles: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html
-.. _latest: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#discovery
-.. _sign the requests: https://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html
+.. _latest: https://cratedb.com/docs/crate/reference/en/latest/config/cluster.html#discovery
+.. _sign the requests: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv.html

--- a/docs/install/cloud/aws/ec2-setup.rst
+++ b/docs/install/cloud/aws/ec2-setup.rst
@@ -196,7 +196,7 @@ discovery by availability zone::
 
 See also :ref:`crate-reference:discovery.ec2.availability_zones`.
 
-.. _3.3: https://cratedb.com/docs/crate/reference/en/3.3/config/cluster.html#discovery
+.. _3.3: https://github.com/crate/crate/blob/3.3/blackbox/docs/config/cluster.rst#discovery
 .. _Amazon EC2: https://aws.amazon.com/ec2/
 .. _assign them with an IAM role: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/attach-iam-role.html
 .. _AWS guide: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html

--- a/docs/install/cloud/azure/vm.rst
+++ b/docs/install/cloud/azure/vm.rst
@@ -174,7 +174,7 @@ We need to allow the ports CrateDB uses through the Windows Firewall
 Start crate by running ``bin/crate``.
 
 
-.. _3.3: https://cratedb.com/docs/crate/reference/en/3.3/config/cluster.html#discovery
+.. _3.3: https://github.com/crate/crate/blob/3.3/blackbox/docs/config/cluster.rst#discovery
 .. _Java JDK installed: https://www.oracle.com/java/technologies/downloads/#java8
 .. _latest: https://cratedb.com/docs/crate/reference/en/latest/config/cluster.html#discovery
 .. _Learn how to install here: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli


### PR DESCRIPTION
## About

We turned off [CrateDB 3.3 docs](https://cratedb.com/docs/crate/reference/en/3.3/) recently.

## Preview

- https://cratedb-guide--359.org.readthedocs.build/admin/clustering/multi-node-setup.html#seeding-manually
- https://cratedb-guide--359.org.readthedocs.build/admin/clustering/scale/kubernetes.html
- https://cratedb-guide--359.org.readthedocs.build/install/cloud/aws/ec2-setup.html#basic-configuration
- https://cratedb-guide--359.org.readthedocs.build/install/cloud/azure/vm.html#configure-cratedb