### PR TITLE
Navigation: Dissolve cross-tree references

### DIFF
--- a/docs/admin/index.md
+++ b/docs/admin/index.md
@@ -32,10 +32,9 @@ Production and troubleshooting guidelines and system resource considerations.
 
 clustering/index
 sharding-partitioning
-../performance/index
 ```
 +++
-Best practices and tips for clustering, sharding, partitioning, and performance tuning.
+Best practices and tips for clustering, sharding, and partitioning.
 ::::
 
 ::::{grid-item-card} {material-outlined}`system_update_alt;2em` Software Upgrades

--- a/docs/start/index.md
+++ b/docs/start/index.md
@@ -114,11 +114,11 @@ and explore key features.
 :hidden:
 
 first-steps
+going-further
 modelling/index
 query/index
 ingest
 application/index
-going-further
 ```
 
 

--- a/docs/start/index.md
+++ b/docs/start/index.md
@@ -114,11 +114,11 @@ and explore key features.
 :hidden:
 
 first-steps
-going-further
 modelling/index
 query/index
-Ingesting data <../ingest/index>
+ingest
 application/index
+going-further
 ```
 
 

--- a/docs/start/ingest.md
+++ b/docs/start/ingest.md
@@ -1,13 +1,6 @@
 (start-ingest)=
 # Ingesting data
 
-:::{card} All data ingestion methods for CrateDB at a glance 
-:link: ingest
-:link-type: ref
-CrateDB's data ingestion guide provides an overview of how to efficiently bring
-data from various sources into CrateDB.
-:::
-
 :::{rubric} Features
 :::
 
@@ -33,3 +26,13 @@ load) process, supporting use cases that range from one-time migrations to
 continuous, real-time data pipelines. As a result, CrateDB is well-suited
 for large-scale analytics, IoT, and time-series workloads that demand
 seamless and flexible ingestion strategies.
+
+:::{rubric} Next step
+:::
+
+:::{card} All data ingestion methods for CrateDB at a glance
+:link: ingest
+:link-type: ref
+CrateDB's data ingestion guide provides an overview of how to efficiently bring
+data from various sources into CrateDB.
+:::

--- a/docs/start/ingest.md
+++ b/docs/start/ingest.md
@@ -1,0 +1,35 @@
+(start-ingest)=
+# Ingesting data
+
+:::{card} All data ingestion methods for CrateDB at a glance 
+:link: ingest
+:link-type: ref
+CrateDB's data ingestion guide provides an overview of how to efficiently bring
+data from various sources into CrateDB.
+:::
+
+:::{rubric} Features
+:::
+
+The platform supports loading data through native methods such as the
+`COPY FROM` SQL statement, enabling import from local files or remote sources
+including HTTP, FTP, and cloud storage providers like AWS S3 and Azure.
+
+Supported formats for ingestion include CSV and JSON Lines, and CrateDB offers
+features for both batch and incremental loads. Additionally, the Foreign Data
+Wrapper feature allows you to access and query external databases as if they
+were local tables, further expanding integration capabilities.
+
+:::{rubric} Integrations
+:::
+
+The guide also highlights advanced options like using third-party tools and
+connectors—such as ingestr—to migrate or synchronise data from a wide array
+of traditional databases, cloud warehouses, message brokers, and file/object
+storage systems.
+
+These integrations help automate and streamline the ETL (extract, transform,
+load) process, supporting use cases that range from one-time migrations to
+continuous, real-time data pipelines. As a result, CrateDB is well-suited
+for large-scale analytics, IoT, and time-series workloads that demand
+seamless and flexible ingestion strategies.

--- a/docs/start/modelling/fulltext.md
+++ b/docs/start/modelling/fulltext.md
@@ -147,7 +147,7 @@ constraints, all in one.
 
 ## Further Learning & Resources
 
-* [**Full-text Search**](../../feature/search/fts/index.md): In-depth
+* {ref}`Full-text Search <fulltext-search>`: In-depth
   walkthrough of full-text search capabilities.
 * Reference Manual:
   * {ref}`Full-text indices <crate-reference:fulltext-indices>`: Defining
@@ -156,5 +156,8 @@ constraints, all in one.
     analyzers, tokenizers, token and char filters.
   * {ref}`SQL MATCH predicate <crate-reference:sql_dql_fulltext_search>`:
     Details about MATCH predicate arguments and options.
-* [**Hands‑On Academy Course**](https://learn.cratedb.com/cratedb-fundamentals?lesson=fulltext-search):
+* [Hands‑On Academy Course]:
   explore FTS on real datasets (e.g. Chicago neighborhoods).
+
+
+[Hands‑On Academy Course]: https://learn.cratedb.com/cratedb-fundamentals?lesson=fulltext-search

--- a/docs/start/query/index.md
+++ b/docs/start/query/index.md
@@ -48,7 +48,7 @@ CrateDB is not just a real-time analytics database, it’s a powerful platform t
 
 aggregations
 ad-hoc
-../../feature/search/index
+search
 ai-integration
 Performance <performance>
 ```

--- a/docs/start/query/search.md
+++ b/docs/start/query/search.md
@@ -1,0 +1,31 @@
+(start-search)=
+# Search
+
+:::{card} All search features of CrateDB at a glance 
+:link: search-overview
+:link-type: ref
+CrateDB provides full-text, geospatial, and vector search natively.
+:::
+
+:::{rubric} Features
+:::
+
+CrateDB offers robust search capabilities by combining native full-text,
+geospatial, vector, and hybrid search—all accessible through standard SQL
+queries. At its core, CrateDB leverages Apache Lucene and the BM25 ranking
+algorithm for high-performance full-text search, making it well-suited for
+large-scale, complex information retrieval tasks.
+
+Geospatial and vector search are also natively supported, enabling use cases
+ranging from text analytics to AI/ML and location-based queries, all within
+the same unified platform.
+
+:::{rubric} Hybrid search
+:::
+
+Hybrid search in CrateDB allows you to combine multiple search methods—such
+as term-based, vector, and geospatial—within a single query for powerful
+information discovery. This versatility, together with horizontal
+scalability and SQL compatibility, makes CrateDB an exceptional choice for
+organisations wanting to run advanced search and analytics on diverse data
+types, including structured, semi-structured, and unstructured content.

--- a/docs/start/query/search.md
+++ b/docs/start/query/search.md
@@ -1,12 +1,6 @@
 (start-search)=
 # Search
 
-:::{card} All search features of CrateDB at a glance 
-:link: search-overview
-:link-type: ref
-CrateDB provides full-text, geospatial, and vector search natively.
-:::
-
 :::{rubric} Features
 :::
 
@@ -29,3 +23,12 @@ information discovery. This versatility, together with horizontal
 scalability and SQL compatibility, makes CrateDB an exceptional choice for
 organisations wanting to run advanced search and analytics on diverse data
 types, including structured, semi-structured, and unstructured content.
+
+:::{rubric} Next step
+:::
+
+:::{card} All search features of CrateDB at a glance
+:link: search-overview
+:link-type: ref
+CrateDB provides full-text, geospatial, and vector search natively.
+:::


### PR DESCRIPTION
## About
References pointing across the document tree have been reported to display confusing navigation behaviour.

## Details
Discovered per `ag "\.\.\/"`.

## Preview
- https://cratedb-guide--362.org.readthedocs.build/start/ingest.html
- https://cratedb-guide--362.org.readthedocs.build/start/query/search.html
