### PR TITLE
Diátaxis: Index how-to guides and tutorials

### DIFF
--- a/docs/_include/links.md
+++ b/docs/_include/links.md
@@ -15,6 +15,7 @@
 [CTE]: inv:crate-reference#sql_dql_with
 [CrateDB BLOBs]: inv:crate-reference:*:label#blob_support
 [CrateDB Cloud]: inv:cloud:*:label#index
+[CrateDB Cloud Console]: https://console.cratedb.cloud/
 [CrateDB JDBC Driver]: https://cratedb.com/docs/jdbc/
 [CrateDB Reference Manual]: inv:crate-reference:*:label#index
 [CrateDB Self-Managed]: https://cratedb.com/product/self-managed

--- a/docs/feature/document/index.md
+++ b/docs/feature/document/index.md
@@ -427,5 +427,5 @@ and about OBJECT indexing.
 :maxdepth: 1
 :hidden:
 
-Usage <usage>
+Tutorial <tutorial>
 ```

--- a/docs/feature/document/tutorial.md
+++ b/docs/feature/document/tutorial.md
@@ -35,7 +35,7 @@ To begin, let's create the schema for this dataset.
 :::{div}
 The fastest and easiest way to get started with CrateDB is by deploying a
 free tier (CRFREE) cluster on [CrateDB Cloud][CrateDB Cloud Console]. Otherwise,
-see the {ref}`install` section about to run CrateDB yourself.
+see the {ref}`install` section to run CrateDB yourself.
 :::
 
 CrateDB uses SQL, the most popular query language for database management. To

--- a/docs/feature/document/tutorial.md
+++ b/docs/feature/document/tutorial.md
@@ -4,9 +4,12 @@
 
 # Objects: Analyzing Marketing Data
 
+:::{include} /_include/links.md
+:::
+
 Marketers often need to handle multi-structured data from different platforms.
 CrateDB's dynamic `OBJECT` data type allows us to store and analyze this complex,
-nested data efficiently. In this usage guide, we'll explore how to leverage this
+nested data efficiently. In this tutorial, we'll explore how to leverage this
 feature in marketing data analysis, along with the use of generated columns to
 parse and manage URLs.
 
@@ -28,6 +31,12 @@ Consider marketing data that captures details of various campaigns.
 To begin, let's create the schema for this dataset.
 
 ## Creating the Table
+
+:::{div}
+The fastest and easiest way to get started with CrateDB is by deploying a
+free tier (CRFREE) cluster on [CrateDB Cloud][CrateDB Cloud Console]. Otherwise,
+see the {ref}`install` section about to run CrateDB yourself.
+:::
 
 CrateDB uses SQL, the most popular query language for database management. To
 store the marketing data, create a table with columns tailored to the
@@ -126,5 +135,5 @@ GROUP BY 1
 ORDER BY 2 DESC;
 :::
 
-In this usage guide, we explored the versatility and power of CrateDB's dynamic
+In this tutorial, we explored the versatility and power of CrateDB's dynamic
 `OBJECT` data type for handling complex, nested marketing data.

--- a/docs/feature/document/usage.md
+++ b/docs/feature/document/usage.md
@@ -1,5 +1,6 @@
 (objects-basics)=
 (objects-usage)=
+(objects-tutorial-marketing)=
 
 # Objects: Analyzing Marketing Data
 

--- a/docs/feature/search/fts/index.md
+++ b/docs/feature/search/fts/index.md
@@ -285,7 +285,7 @@ files, and corresponding technical backgrounds about their implementations.
 The usage guide illustrates the BM25 ranking algorithm for information retrieval,
 by exploring how to manage a dataset of Netflix titles.
 
-{hyper-navigate}`Netflix Tutorial <search-fts-usage>`
+{hyper-navigate}`Netflix Tutorial <search-tutorial-netflix>`
 
 
 :::
@@ -374,7 +374,7 @@ and how they can be customized to specific needs, using plugins for CrateDB.
 
 options
 analyzer
-Usage <usage>
+Tutorial <tutorial>
 :::
 
 

--- a/docs/feature/search/fts/tutorial.md
+++ b/docs/feature/search/fts/tutorial.md
@@ -32,7 +32,7 @@ To begin, let's create the schema for this dataset.
 :::{div}
 The fastest and easiest way to get started with CrateDB is by deploying a
 free tier (CRFREE) cluster on [CrateDB Cloud][CrateDB Cloud Console]. Otherwise,
-see the {ref}`install` section about to run CrateDB yourself.
+see the {ref}`install` section to run CrateDB yourself.
 :::
 
 CrateDB uses SQL, the most popular query language for database management. To

--- a/docs/feature/search/fts/tutorial.md
+++ b/docs/feature/search/fts/tutorial.md
@@ -4,7 +4,10 @@
 
 # Full-Text: Exploring the Netflix Catalog
 
-In this usage guide, we will explore how to manage a dataset of Netflix titles,
+:::{include} /_include/links.md
+:::
+
+In this tutorial, we will explore how to manage a dataset of Netflix titles,
 making use of CrateDB Cloud's full-text search capabilities.
 Each entry in our imaginary dataset will have the following attributes:
 
@@ -25,6 +28,12 @@ To begin, let's create the schema for this dataset.
 
 
 ## Creating the Table
+
+:::{div}
+The fastest and easiest way to get started with CrateDB is by deploying a
+free tier (CRFREE) cluster on [CrateDB Cloud][CrateDB Cloud Console]. Otherwise,
+see the {ref}`install` section about to run CrateDB yourself.
+:::
 
 CrateDB uses SQL, the most popular query language for database management. To
 store the data, create a table with columns tailored to the

--- a/docs/handbook/index.md
+++ b/docs/handbook/index.md
@@ -2,12 +2,13 @@
 
 # Handbook
 
-Guides and tutorials about how to use CrateDB and CrateDB Cloud in practice.
+:::{div} sd-text-muted
+About using CrateDB and CrateDB Cloud in practice.
+:::
 
 
 ::::{grid} 4
 :padding: 0
-
 
 :::{grid-item-card} Getting Started
 :link: getting-started
@@ -18,10 +19,8 @@ Guides and tutorials about how to use CrateDB and CrateDB Cloud in practice.
 :class-card: sd-pt-3
 :class-body: sd-fs-1
 :class-title: sd-fs-5
-
 {material-outlined}`rocket_launch;1.3em`
 :::
-
 
 :::{grid-item-card} Installation
 :link: install
@@ -32,10 +31,54 @@ Guides and tutorials about how to use CrateDB and CrateDB Cloud in practice.
 :class-card: sd-pt-3
 :class-body: sd-fs-1
 :class-title: sd-fs-5
-
 {material-outlined}`download_for_offline;1.3em`
 :::
 
+:::{grid-item-card} Connect
+:link: connect
+:link-type: ref
+:link-alt: Connecting to CrateDB
+:padding: 1
+:text-align: center
+:class-card: sd-pt-3
+:class-body: sd-fs-1
+:class-title: sd-fs-5
+{material-outlined}`settings_input_svideo;1.3em`
+:::
+
+::::
+
+
+## Learn
+
+How-to guides, tutorials, and explanations.
+
+::::{grid} 4
+:padding: 0
+
+:::{grid-item-card} How-to guides
+:link: howtos
+:link-type: ref
+:link-alt: How-to guides about CrateDB
+:padding: 1
+:text-align: center
+:class-card: sd-pt-3
+:class-body: sd-fs-1
+:class-title: sd-fs-5
+{material-outlined}`assistant_direction;1.3em`
+:::
+
+:::{grid-item-card} Tutorials
+:link: tutorials
+:link-type: ref
+:link-alt: Tutorials about CrateDB
+:padding: 1
+:text-align: center
+:class-card: sd-pt-3
+:class-body: sd-fs-1
+:class-title: sd-fs-5
+{material-outlined}`school;1.3em`
+:::
 
 :::{grid-item-card} Administration
 :link: administration
@@ -46,24 +89,20 @@ Guides and tutorials about how to use CrateDB and CrateDB Cloud in practice.
 :class-card: sd-pt-3
 :class-body: sd-fs-1
 :class-title: sd-fs-5
-
-{material-outlined}`auto_stories;1.3em`
+{material-outlined}`manage_accounts;1.3em`
 :::
 
-
-:::{grid-item-card} Performance Guides
+:::{grid-item-card} Performance guides
 :link: performance
 :link-type: ref
-:link-alt: CrateDB Performance Guides
+:link-alt: CrateDB Performance guides
 :padding: 1
 :text-align: center
 :class-card: sd-pt-3
 :class-body: sd-fs-1
 :class-title: sd-fs-5
-
 {material-outlined}`speed;1.3em`
 :::
-
 
 ::::
 
@@ -222,13 +261,13 @@ programming frameworks, software testing, time series data.
 
 ../install/index
 ../connect/index
+../howto/index
+../tutorial/index
+../admin/index
+../performance/index
 ../feature/index
 Ingestion <../ingest/index>
 ../topic/index
 Solutions <../solution/index>
 ../integrate/index
-../admin/index
-../performance/index
-../howto/index
-../tutorial/index
 ```

--- a/docs/handbook/index.md
+++ b/docs/handbook/index.md
@@ -1,7 +1,4 @@
-(guides)=
-(howtos)=
-(tutorials)=
-(use-more-tutorials)=
+(handbook)=
 
 # Handbook
 

--- a/docs/handbook/index.md
+++ b/docs/handbook/index.md
@@ -232,4 +232,6 @@ Solutions <../solution/index>
 ../integrate/index
 ../admin/index
 ../performance/index
+../howto/index
+../tutorial/index
 ```

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -1,0 +1,6 @@
+(howtos)=
+(howto-guides)=
+
+# How-to guides
+
+Todo.

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -1,6 +1,76 @@
+(guides)=
 (howtos)=
 (howto-guides)=
 
 # How-to guides
 
-Todo.
+:::{div} sd-text-muted
+Instructions how to get tasks done with CrateDB.
+:::
+
+:::{rubric} 2025
+:::
+
+- {ref}`influxdb-usage`
+- {ref}`amqp-usage`
+- {ref}`mqtt-usage`
+- {ref}`mongodb-usage`
+- {ref}`mysql-usage`
+- {ref}`oracle-usage`
+- {ref}`postgresql-usage`
+- {ref}`telegraf-usage`
+- {ref}`statsd-usage`
+- {ref}`rsyslog-usage`
+- {ref}`opentelemetry-telegraf-usage`
+- {ref}`opentelemetry-otelcol-usage`
+- {ref}`iceberg-risingwave`
+
+:::{rubric} 2024
+:::
+
+- {ref}`arrow-import-parquet`
+- {ref}`kafka-connect`
+- {ref}`superset-usage`
+- {ref}`superset-sandbox`
+- {ref}`cluvio-usage`
+- {ref}`dapr-usage`
+- {ref}`An example with Datashader <datashader>`
+- {ref}`dask-usage`
+- {ref}`dbt-usage`
+- {ref}`Using JMeter with CrateDB <jmeter>`
+- {ref}`langchain-usage`
+- {ref}`metabase-usage`
+- {ref}`pandas-efficient-ingest`
+- {ref}`PyCaret and CrateDB <pycaret>`
+- {ref}`rill-usage`
+- {ref}`marquez-usage`
+
+:::{rubric} 2023
+:::
+
+- {ref}`Using DataGrip <datagrip>`
+- {ref}`Using DBeaver <dbeaver>`
+- {ref}`balena-usage`
+- {ref}`kestra-usage`
+- {ref}`nifi-usage`
+- {ref}`powerbi-desktop`
+- {ref}`powerbi-service`
+- {ref}`streamsets-usage`
+- {ref}`spark-usage`
+- {ref}`azure-databricks`
+- {ref}`prefect-usage`
+- {ref}`terraform-usage`
+- {ref}`trino-usage`
+
+:::{rubric} 2022
+:::
+
+- {ref}`prometheus-usage`
+
+
+:::{note}
+You can expect the more recent documents to be more up-to-date than previous
+ones. If you can discover any flaws, please report them back to us by
+navigating to the tool flyout in the top right corner of each page,
+then using "Suggest improvement" to leave your feedback.
+:::

--- a/docs/integrate/influxdb/usage.md
+++ b/docs/integrate/influxdb/usage.md
@@ -1,5 +1,5 @@
 (influxdb-usage)=
-# Import data from InfluxDB
+# Load data from InfluxDB
 
 In this quick usage guide, you will use the [CrateDB Toolkit InfluxDB I/O subsystem]
 to import data from [InfluxDB] into [CrateDB]. You can also import data directly

--- a/docs/integrate/locust/tutorial.md
+++ b/docs/integrate/locust/tutorial.md
@@ -479,7 +479,7 @@ If you want to download the locust data, you can do that on the last tab.
 When you want to run a load test against a CrateDB Cluster with multiple queries, Locust is a great and flexible tool that lets you quickly define a load test and see what numbers regarding users and RPS are possible for that particular setup.
 
 
-[CrateDB CLI tools]: https://cratedb.com/docs/crate/clients-tools/en/latest/connect/cli.html#cli
+[CrateDB CLI tools]: project:#cli
 [DBeaver]: https://dbeaver.io
 [fully-managed]: https://console.cratedb.cloud/
 [Locust]: https://locust.io

--- a/docs/topic/timeseries/learn/query.md
+++ b/docs/topic/timeseries/learn/query.md
@@ -57,7 +57,7 @@ readings from CrateDB offices across the globe. Each record includes:
 :::{div}
 The fastest and easiest way to get started with CrateDB is by deploying a
 free tier (CRFREE) cluster on [CrateDB Cloud][CrateDB Cloud Console]. Otherwise,
-see the {ref}`install` section about to run CrateDB yourself.
+see the {ref}`install` section to run CrateDB yourself.
 :::
 
 CrateDB uses SQL, the most popular query language for database management. To

--- a/docs/topic/timeseries/learn/query.md
+++ b/docs/topic/timeseries/learn/query.md
@@ -5,6 +5,9 @@
 
 # Analyzing Weather Data
 
+:::{include} /_include/links.md
+:::
+
 CrateDB is a powerful database designed to handle various use cases, one of
 which is managing time series data. Time series data refers to collections of
 data points recorded at specific intervals over time, like the hourly
@@ -50,6 +53,12 @@ readings from CrateDB offices across the globe. Each record includes:
 
 
 ## Creating the Table
+
+:::{div}
+The fastest and easiest way to get started with CrateDB is by deploying a
+free tier (CRFREE) cluster on [CrateDB Cloud][CrateDB Cloud Console]. Otherwise,
+see the {ref}`install` section about to run CrateDB yourself.
+:::
 
 CrateDB uses SQL, the most popular query language for database management. To
 store the weather data, create a table with columns tailored to the

--- a/docs/topic/timeseries/learn/query.md
+++ b/docs/topic/timeseries/learn/query.md
@@ -1,6 +1,7 @@
 (timeseries-analysis-advanced)=
 (timeseries-analysis-weather)=
 (timeseries-querying)=
+(timeseries-tutorial-weather)=
 
 # Analyzing Weather Data
 

--- a/docs/topic/timeseries/learn/with-metadata.md
+++ b/docs/topic/timeseries/learn/with-metadata.md
@@ -57,7 +57,7 @@ like manufacturer, model, and firmware version.
 :::{div}
 The fastest and easiest way to get started with CrateDB is by deploying a
 free tier (CRFREE) cluster on [CrateDB Cloud][CrateDB Cloud Console]. Otherwise,
-see the {ref}`install` section about to run CrateDB yourself.
+see the {ref}`install` section to run CrateDB yourself.
 :::
 
 CrateDB uses SQL, the most popular query language for database management. To

--- a/docs/topic/timeseries/learn/with-metadata.md
+++ b/docs/topic/timeseries/learn/with-metadata.md
@@ -4,6 +4,9 @@
 
 # Analyzing Device Readings with Metadata Integration
 
+:::{include} /_include/links.md
+:::
+
 CrateDB is highly regarded as an optimal database solution for managing
 time series data thanks to its unique blend of features. It is particularly
 effective when you need to combine time series data with metadata, for
@@ -50,6 +53,12 @@ like manufacturer, model, and firmware version.
 
 
 ## Creating the Tables
+
+:::{div}
+The fastest and easiest way to get started with CrateDB is by deploying a
+free tier (CRFREE) cluster on [CrateDB Cloud][CrateDB Cloud Console]. Otherwise,
+see the {ref}`install` section about to run CrateDB yourself.
+:::
 
 CrateDB uses SQL, the most popular query language for database management. To
 store the device readings and the device info data, define two tables with
@@ -126,7 +135,7 @@ WITH (compression='gzip', empty_string_as_null=true)
 RETURN SUMMARY;
 :::
 
-## Time Series Analysis with Metadata
+## Analyzing Data
 
 
 :::{rubric} JOIN Operations

--- a/docs/topic/timeseries/learn/with-metadata.md
+++ b/docs/topic/timeseries/learn/with-metadata.md
@@ -1,5 +1,6 @@
 (timeseries-objects)=
 (timeseries-with-metadata)=
+(timeseries-tutorial-metadata)=
 
 # Analyzing Device Readings with Metadata Integration
 

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -3,22 +3,94 @@
 
 # Tutorials
 
+:::{div} sd-text-muted
+Acquire skills and knowledge about how to interact with CrateDB along
+the lines of a few learning sessions.
+:::
+
 ## Get started
 
-Learn about fundamental features of CrateDB.
+Learn about fundamental features of CrateDB with hands-on example tutorials.
 
-- {ref}`objects-tutorial-marketing`
-- {ref}`search-tutorial-netflix`
-- {ref}`timeseries-tutorial-metadata`
-- {ref}`timeseries-tutorial-weather`
+:::::{grid} 2
+:padding: 0
+:gutter: 4
+
+::::{grid-item-card} Objects: Analyzing Marketing Data
+:link: objects-tutorial-marketing
+:link-type: ref
+CrateDB’s dynamic OBJECT data type can store and analyze complex and nested data efficiently.
+::::
+
+::::{grid-item-card} Full-Text: Exploring the Netflix Catalog
+:link: search-tutorial-netflix
+:link-type: ref
+Learn how to make use of CrateDB's full-text search capabilities.
+::::
+
+::::{grid-item-card} Analyzing Device Readings with Metadata Integration
+:link: timeseries-tutorial-metadata
+:link-type: ref
+Learn how to combine time series data with metadata.
+::::
+
+::::{grid-item-card} Analyzing Weather Data
+:link: timeseries-tutorial-weather
+:link-type: ref
+Learn how to analyze time series data on behalf of a practical example.
+::::
+
+:::::
+
+
+## Academy
+
+:::{card}
+:width: 50%
+:link: https://learn.cratedb.com/
+:link-alt: The CrateDB Academy
+:class-header: sd-text-center sd-fs-5 sd-align-minor-center sd-font-weight-bold sd-text-capitalize
+:class-body: sd-text-center sd-fs-5
+:class-footer: text-smaller
+Academy Courses
+^^^
+{material-outlined}`school;3.5em`
++++
+A learning hub dedicated to data enthusiasts, including educational material
+about CrateDB fundamentals and advanced time series.
+:::
+
 
 ## Integrations
 
 Learn how to integrate CrateDB with 3rd-party, industry-standard products.
 
-- {ref}`grafana-tutorial`
+:::{rubric} 2024
+:::
+- {ref}`airflow-import-parquet`
+- {ref}`airflow-export-s3`
+- {ref}`airflow-data-retention-policy`
+- {ref}`airflow-data-retention-hot-cold`
 - {ref}`debezium-tutorial`
 - {ref}`azure-functions-tutorial`
+- {ref}`locust-tutorial`
+
+:::{rubric} 2023
+:::
+- {ref}`node-red-tutorial`
+- {ref}`pandas-tutorial-start`
+- {ref}`pandas-tutorial-jupyter`
+
+:::{rubric} 2021
+:::
+- {ref}`grafana-tutorial`
 - {ref}`tensorflow-tutorial`
 - {ref}`r-tutorial`
-- {ref}`locust-tutorial`
+
+
+:::{note}
+You can expect the more recent documents to be more up-to-date than previous
+ones. If you can discover any flaws, please report them back to us by
+navigating to the tool flyout in the top right corner of each page,
+then using "Suggest improvement" to leave your feedback.
+:::

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -1,0 +1,24 @@
+(tutorials)=
+(use-more-tutorials)=
+
+# Tutorials
+
+## Get started
+
+Learn about fundamental features of CrateDB.
+
+- {ref}`objects-tutorial-marketing`
+- {ref}`search-tutorial-netflix`
+- {ref}`timeseries-tutorial-metadata`
+- {ref}`timeseries-tutorial-weather`
+
+## Integrations
+
+Learn how to integrate CrateDB with 3rd-party, industry-standard products.
+
+- {ref}`grafana-tutorial`
+- {ref}`debezium-tutorial`
+- {ref}`azure-functions-tutorial`
+- {ref}`tensorflow-tutorial`
+- {ref}`r-tutorial`
+- {ref}`locust-tutorial`


### PR DESCRIPTION
## About

After phasing out the [crate-howtos] and [crate-tutorials] repositories, and re-integrating content here, let's use ideas from Diátaxis to loosely start grouping/indexing relevant content again.

Remark: Not many articles enumerated at [Overview of CrateDB integration tutorials] are actually tutorials per [Diátaxis "tutorials" definition], so we slotted most of them into the "how-to" section instead.

## Preview

- https://cratedb-guide--364.org.readthedocs.build/handbook/#learn
- https://cratedb-guide--364.org.readthedocs.build/howto/
- https://cratedb-guide--364.org.readthedocs.build/tutorial/

## References

- GH-10
- https://github.com/crate/cloud-docs/issues/68
- GH-102
- GH-227
- GH-335

[crate-howtos]: https://github.com/crate/crate-howtos
[crate-tutorials]: https://github.com/crate/crate-tutorials
[Diátaxis "tutorials" definition]: https://diataxis.fr/tutorials/
[Overview of CrateDB integration tutorials]: https://community.cratedb.com/t/overview-of-cratedb-integration-tutorials/1015
