### PR TITLE
Chore: Remove "Overview of CrateDB integration tutorials"

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@
 
 📖 More information:
 [Drivers and Integrations](https://cratedb.com/docs/clients/) •
-[Integration Tutorials](https://community.cratedb.com/t/overview-of-cratedb-integration-tutorials/1015) •
 [Reference Documentation](https://cratedb.com/docs/crate/reference/)
 
 ✅ CI Status:

--- a/docs/integrate/index.md
+++ b/docs/integrate/index.md
@@ -9,10 +9,6 @@ This documentation section lists applications, frameworks, and libraries,
 which can be used together with CrateDB, and outlines how to use them
 optimally.
 
-:::{tip}
-Please also visit the [Overview of CrateDB integration tutorials].
-:::
-
 :::{toctree}
 :maxdepth: 1
 :glob:
@@ -22,4 +18,3 @@ Please also visit the [Overview of CrateDB integration tutorials].
 
 
 [CrateDB's PostgreSQL interface]: inv:crate-reference#interface-postgresql
-[Overview of CrateDB integration tutorials]: https://community.cratedb.com/t/overview-of-cratedb-integration-tutorials/1015

--- a/docs/solution/migrate/rockset/index.md
+++ b/docs/solution/migrate/rockset/index.md
@@ -302,8 +302,7 @@ CrateDB offers a wide range of integration capabilities, is compatible
 with the PostgreSQL wire protocol, and offers adapter components to
 integrate with applications and frameworks.
 
-- [Integration Tutorials I]
-- [Integration Tutorials II]
+- [Integration Guides]
 - [Software Development Kit]
 
 :::{rubric} Integrating CrateDB technologies into Rockset-based infrastructure
@@ -330,8 +329,7 @@ and Python example programs.
 [CrateDB Editions]: https://cratedb.com/database/editions
 [CrateDB SQL]: project:#sql
 [DX]: https://en.wikipedia.org/wiki/User_experience#Developer_experience
-[Integration Tutorials I]: inv:#integrate
-[Integration Tutorials II]: https://community.cratedb.com/t/overview-of-cratedb-integration-tutorials/1015
+[Integration Guides]: project:#integrate
 [migration]: https://cratedb.com/migrations/rockset
 [MongoDB Atlas Change Streams]: https://www.mongodb.com/docs/manual/changeStreams/
 [open-source code base]: https://github.com/crate/crate


### PR DESCRIPTION
## About

All the Markdown has been migrated to the CrateDB Guide / Handbook.

-- https://community.cratedb.com/t/overview-of-cratedb-integration-tutorials/1015

## References
- https://github.com/crate/cratedb-guide/issues/102