### PR TITLE
Navigation: Relocate reference links in learning path sections

### DIFF
--- a/docs/_include/links.md
+++ b/docs/_include/links.md
@@ -1,6 +1,7 @@
 <!-- markdownlint-disable MD034 -->
 <!-- markdownlint-disable MD053 -->
 
+[ADBC]: https://arrow.apache.org/docs/format/ADBC.html
 [Admin UI]: inv:crate-admin-ui:*:label#index
 [Amazon DynamoDB Streams]: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.html
 [Amazon Kinesis Data Streams]: https://docs.aws.amazon.com/streams/latest/dev/introduction.html
@@ -16,6 +17,7 @@
 [CrateDB BLOBs]: inv:crate-reference:*:label#blob_support
 [CrateDB Cloud]: inv:cloud:*:label#index
 [CrateDB Cloud Console]: https://console.cratedb.cloud/
+[CrateDB Examples]: https://github.com/crate/cratedb-examples
 [CrateDB JDBC Driver]: https://cratedb.com/docs/jdbc/
 [CrateDB Reference Manual]: inv:crate-reference:*:label#index
 [CrateDB Self-Managed]: https://cratedb.com/product/self-managed
@@ -37,9 +39,11 @@
 [HNSW paper]: https://arxiv.org/pdf/1603.09320
 [HoloViews]: https://www.holoviews.org/
 [HoloViz]: https://holoviz.org/
+[HTTP protocol]: https://en.wikipedia.org/wiki/HTTP
 [Indexing, Columnar Storage, and Aggregations]: https://cratedb.com/product/features/indexing-columnar-storage-aggregations
 [InfluxDB]: https://github.com/influxdata/influxdb
 [inverted index]: https://en.wikipedia.org/wiki/Inverted_index
+[JDBC]: https://en.wikipedia.org/wiki/Java_Database_Connectivity
 [JOIN]: inv:crate-reference#sql_joins
 [JSON Database]: https://cratedb.com/solutions/json-database
 [kNN]: https://en.wikipedia.org/wiki/K-nearest_neighbor_algorithm
@@ -60,7 +64,9 @@
 [Multi-model Database]: https://cratedb.com/solutions/multi-model-database
 [nearest neighbor search]: https://en.wikipedia.org/wiki/Nearest_neighbor_search
 [Nested Data Structure]: https://cratedb.com/product/features/nested-data-structure
+[ODBC]: https://en.wikipedia.org/wiki/Open_Database_Connectivity
 [PostgreSQL JDBC Driver]: https://jdbc.postgresql.org/
+[PostgreSQL wire protocol]: https://www.postgresql.org/docs/current/protocol.html
 [python-dbapi-by-example]: inv:crate-python:*:label#by-example
 [python-sqlalchemy-by-example]: inv:sqlalchemy-cratedb:*:label#by-example
 [query DSL based on JSON]: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
@@ -69,6 +75,7 @@
 [Replicating CDC events from DynamoDB to CrateDB]: https://cratedb.com/blog/replicating-cdc-events-from-dynamodb-to-cratedb
 [Replicating CDC events to CrateDB using AWS DMS]: https://cratedb.com/blog/replicating-cdc-events-to-cratedb-using-aws-dms
 [Replicating data to CrateDB with Debezium and Kafka]: https://community.cratedb.com/t/replicating-data-to-cratedb-with-debezium-and-kafka/1388
+[SQL]: https://en.wikipedia.org/wiki/Sql
 [TF–IDF]: https://en.wikipedia.org/wiki/Tf%E2%80%93idf
 [timeseries-queries-and-visualization-colab]: https://colab.research.google.com/github/crate/cratedb-examples/blob/main/topic/timeseries/timeseries-queries-and-visualization.ipynb
 [timeseries-queries-and-visualization-github]: https://github.com/crate/cratedb-examples/blob/main/topic/timeseries/timeseries-queries-and-visualization.ipynb

--- a/docs/connect/index.md
+++ b/docs/connect/index.md
@@ -45,24 +45,17 @@ protocol.
 :class: rubric-slim
 :columns: auto 3 3 3
 
-```{rubric} Reference Manual
+```{rubric} Reference
 ```
 - [HTTP interface]
 - [PostgreSQL interface]
-- [SQL query syntax]
-- [Bulk operations]
-- [BLOB support][CrateDB BLOBs]
-
-```{rubric} Protocols and API Standards
-```
-- [HTTP protocol]
-- [PostgreSQL wire protocol]
-- [JDBC]
-- [ODBC]
-- [SQL]
 
 ```{rubric} Related
 ```
+- [Authentication]
+- [SQL query syntax]
+- [Bulk operations]
+- [BLOB support][CrateDB BLOBs]
 - {ref}`All drivers <connect-drivers>`
 ::::
 
@@ -193,18 +186,8 @@ All drivers <drivers>
 ```
 
 
-[ADBC]: https://arrow.apache.org/docs/format/ADBC.html
 [Authentication]: inv:crate-reference:*:label#admin_auth
 [Bulk operations]: inv:crate-reference:*:label#http-bulk-ops
-[CrateDB Examples]: https://github.com/crate/cratedb-examples
 [HTTP interface]: inv:crate-reference:*:label#interface-http
-[HTTP protocol]: https://en.wikipedia.org/wiki/HTTP
-[JDBC]: https://en.wikipedia.org/wiki/Java_Database_Connectivity
-[ODBC]: https://en.wikipedia.org/wiki/Open_Database_Connectivity
 [PostgreSQL interface]: inv:crate-reference:*:label#interface-postgresql
-[PostgreSQL wire protocol]: https://www.postgresql.org/docs/current/protocol.html
-[schema]: inv:crate-reference:*:label#ddl-create-table-schemas
-[schemas]: inv:crate-reference:*:label#ddl-create-table-schemas
-[SQL]: https://en.wikipedia.org/wiki/Sql
 [SQL query syntax]: inv:crate-reference:*:label#sql
-[superuser]: inv:crate-reference:*:label#administration_user_management

--- a/docs/start/query/ad-hoc.md
+++ b/docs/start/query/ad-hoc.md
@@ -5,13 +5,6 @@
 Support highly dynamic ad-hoc querying even on large-scale, real-time datasets.
 :::
 
-:::::{grid}
-:padding: 0
-
-::::{grid-item}
-:class: rubric-slimmer
-:columns: auto 9 9 9
-
 :::{rubric} Introduction
 :::
 
@@ -55,35 +48,6 @@ They are unpredictable by nature—and CrateDB is designed to handle exactly tha
 - **Query fresh data instantly**, without waiting for batch jobs
 - Combine structured + JSON + full-text + spatial + vector data
 - Avoid maintaining rigid ETL pipelines or OLAP cubes
-
-
-::::
-
-::::{grid-item}
-:class: rubric-slim
-:columns: auto 3 3 3
-
-:::{rubric} Related Features
-:::
-- {ref}`object`
-- {ref}`fts`
-- {ref}`timeseries`
-
-:::{rubric} Reference Documentation
-:::
-- {ref}`CrateDB SQL Reference <crate-reference:sql>`
-- {ref}`CrateDB Console <crate-crash:index>`
-- {ref}`crate-reference:data-types-objects`
-- {ref}`crate-reference:fulltext-indices`
-
-:::{rubric} Learn more
-:::
-- [Exploratory Time Series Data Analysis]
-- [Academy: Time Series Query Optimization]
-- [CrateDB Scalability Benchmark: Query Throughput]
-::::
-
-:::::
 
 
 ## Common Query Patterns
@@ -240,6 +204,38 @@ Learn more about how to use ad-hoc queries effectively.
 | Time series support                   | Perfect for time-bound diagnostics                                                   | {ref}`timeseries`                                            |
 | Intelligent indexing                  | Works out of the box for ad-hoc querying                                             | {ref}`search-overview`                                                |
 | Full-text & filter                    | Combine keyword search with structured queries                                       | {ref}`fts` <br> {ref}`crate-reference:fulltext-indices`      |
+
+
+## Further reading
+
+:::::{grid} 1 3 3 3
+:margin: 4 4 0 0
+:padding: 0
+:gutter: 2
+
+::::{grid-item-card} {material-outlined}`article;1.5em` Documentation
+:columns: 3
+- {ref}`SQL reference <crate-reference:sql>`
+- {ref}`crate-reference:data-types-objects`
+- {ref}`crate-reference:fulltext-indices`
+::::
+
+::::{grid-item-card} {material-outlined}`link;1.5em` Related
+:columns: 3
+- {ref}`object`
+- {ref}`fts`
+- {ref}`timeseries`
+- {ref}`CrateDB Console <crate-crash:index>`
+::::
+
+::::{grid-item-card} {material-outlined}`read_more;1.5em` Read more
+:columns: 6
+- [Exploratory Time Series Data Analysis]
+- [Academy: Time Series Query Optimization]
+- [CrateDB Scalability Benchmark: Query Throughput]
+::::
+
+:::::
 
 
 [Academy: Time Series Query Optimization]: https://cratedb.com/academy/time-series/time-series-data-manipulation-and-visualization/time-series-query-optimization

--- a/docs/start/query/aggregations.md
+++ b/docs/start/query/aggregations.md
@@ -6,13 +6,6 @@
 High-performance aggregations on massive volumes of data using SQL.
 :::
 
-:::::{grid}
-:padding: 0
-
-::::{grid-item}
-:class: rubric-slimmer
-:columns: auto 9 9 9
-
 :::{rubric} Introduction
 :::
 
@@ -36,34 +29,6 @@ Whether you are monitoring sensor networks, analyzing customer behavior, or powe
 | Real-time ingestion           | Query freshly ingested data without delay                                |
 | Aggregations on any data type | Structured, JSON, full-text, geospatial, or vector                       |
 | Smart indexing                | Built-in indexing and configuration options that can boost performance   |
-
-::::
-
-::::{grid-item}
-:class: rubric-slim
-:columns: auto 3 3 3
-
-:::{rubric} Documentation
-:::
-- {ref}`crate-reference:aggregation`
-- {ref}`performance-select`
-
-:::{rubric} Integrations
-:::
-- {ref}`grafana`
-- {ref}`metabase`
-- {ref}`powerbi`
-- {ref}`superset`
-- {ref}`tableau`
-
-:::{rubric} See also
-:::
-- {ref}`analytics`
-- [Hands-on: Aggregating and Grouping Data]
-- [Real-Time Analytics Primer]
-::::
-
-:::::
 
 
 ## Supported Aggregation Functions
@@ -217,5 +182,37 @@ To learn about the full set of integrations, please visit the
 documentation at {ref}`bi` and {ref}`visualization`.
 
 
-[Hands-on: Aggregating and Grouping Data]: https://cratedb.com/academy/fundamentals/working-with-data-in-cratedb/hands-on-aggregating-and-grouping-data
-[Real-Time Analytics Primer]: https://cratedb.com/real-time-analytics/definition
+## Further reading
+
+:::::{grid} 1 3 3 3
+:margin: 4 4 0 0
+:padding: 0
+:gutter: 2
+
+::::{grid-item-card} {material-outlined}`article;1.5em` Documentation
+:columns: 3
+- {ref}`crate-reference:aggregation`
+- {ref}`performance-select`
+::::
+
+::::{grid-item-card} {material-outlined}`integration_instructions;1.5em` Integrations
+:columns: 3
+- {ref}`grafana`
+- {ref}`metabase`
+- {ref}`powerbi`
+- {ref}`superset`
+- {ref}`tableau`
+::::
+
+::::{grid-item-card} {material-outlined}`read_more;1.5em` Read more
+:columns: 6
+- Learn: [Real-time analytics primer]
+- Learn: [Hands-on: Aggregating and grouping data]
+- Solution: {ref}`analytics`
+::::
+
+:::::
+
+
+[Hands-on: Aggregating and grouping data]: https://cratedb.com/academy/fundamentals/working-with-data-in-cratedb/hands-on-aggregating-and-grouping-data
+[Real-time analytics primer]: https://cratedb.com/real-time-analytics/definition

--- a/docs/start/query/ai-integration.md
+++ b/docs/start/query/ai-integration.md
@@ -1,13 +1,6 @@
 (ai-integration)=
 # AI integration
 
-:::::{grid}
-:padding: 0
-
-::::{grid-item}
-:class: rubric-slimmer
-:columns: auto 9 9 9
-
 :::{rubric} Introduction
 :::
 
@@ -33,36 +26,6 @@ Whether you're training models, running batch or real-time inference, or integra
 | Monitoring          | Track model performance, drift, or input quality      |
 | Data Collection     | Capture telemetry, events, logs, and raw user data    |
 
-::::
-
-::::{grid-item}
-:class: rubric-slim
-:columns: auto 3 3 3
-
-:::{rubric} Related
-:::
-- {ref}`vector-search`
-- {ref}`hybrid-search`
-- {ref}`Machine Learning <ml>`
-
-:::{rubric} Integrations
-:::
-- {ref}`langchain`
-- {ref}`llamaindex`
-- {ref}`mindsdb`
-- {ref}`mlflow`
-- {ref}`pycaret`
-
-:::{rubric} See also
-:::
-- [Blog: Vector support and KNN search]
-- {ref}`Synopsis: Text-to-SQL <llamaindex-synopsis>`
-- {ref}`Tutorial: Text-to-SQL using Azure <llamaindex-usage-azure>`
-- [Examples: ML]
-
-::::
-
-:::::
 
 :::{rubric} Use cases
 :::
@@ -231,6 +194,39 @@ Learn more about how to combine ML features with other major features of CrateDB
 | Joins & aggregates  | Combine data in real-time                   | {ref}`relational`, {ref}`aggregations` |
 | Time-series support | Perfect for sensor-based training data      | {ref}`timeseries`                      |
 
+
+## Further reading
+
+:::::{grid} 1 3 3 3
+:margin: 4 4 0 0
+:padding: 0
+:gutter: 2
+
+::::{grid-item-card} {material-outlined}`article;1.5em` Documentation
+:columns: 3
+- {ref}`vector-search`
+- {ref}`hybrid-search`
+- {ref}`Machine Learning <ml>`
+::::
+
+::::{grid-item-card} {material-outlined}`integration_instructions;1.5em` Integrations
+:columns: 3
+- {ref}`langchain`
+- {ref}`llamaindex`
+- {ref}`mindsdb`
+- {ref}`mlflow`
+- {ref}`pycaret`
+::::
+
+::::{grid-item-card} {material-outlined}`read_more;1.5em` Read more
+:columns: 6
+- [Blog: Vector support and KNN search]
+- {ref}`Synopsis: Text-to-SQL <llamaindex-synopsis>`
+- {ref}`Tutorial: Text-to-SQL using Azure <llamaindex-usage-azure>`
+- [Examples: ML]
+::::
+
+:::::
 
 
 [Blog: Vector support and KNN search]: https://cratedb.com/blog/unlocking-the-power-of-vector-support-and-knn-search-in-cratedb


### PR DESCRIPTION
## About

In pure "learning path" sections, relocate reference links to bottom of page.

## Preview

- https://cratedb-guide--379.org.readthedocs.build/start/query/aggregations.html
- https://cratedb-guide--379.org.readthedocs.build/start/query/ad-hoc.html
- https://cratedb-guide--379.org.readthedocs.build/start/query/ai-integration.html

## References

- GH-372
