### PR TITLE
Modernizing the JS examples

### DIFF
--- a/docs/connect/javascript.md
+++ b/docs/connect/javascript.md
@@ -54,7 +54,7 @@ Example implementation will look like this:
 ```javascript
 import { default as crate } from "node-crate";
 
-crate.connect(`https://admin:"<PASSWORD>"}@<name-of-your-cluster>.cratedb.net:4200`);
+crate.connect(`https://admin:<PASSWORD>@<name-of-your-cluster>.cratedb.net:4200`);
 
 const result = await crate.execute("SELECT * FROM sys.summits LIMIT 3");
 console.log(result.rows[0]);


### PR DESCRIPTION
## Admin

As `import` is replacing `require` in contemporary node.js applications, the examples are updated to follow it. With a recent node.js version, it is possible to use `await` in the global scope.

## Preview

 - https://cratedb-guide--391.org.readthedocs.build/connect/javascript.html
