### PR TITLE
Chore: s/further reading.*/see also/

### DIFF
--- a/docs/admin/circuit-breaker.md
+++ b/docs/admin/circuit-breaker.md
@@ -77,7 +77,7 @@ Similar exceptions exist for the other breaker types `[request]`, `[parent]`, `[
 If you experience a `CircuitBreakingException [parent]` it is because other queries/tasks were running simultaneously and their summed estimate
 exceeded `indices.breaker.total.limit`.
 
-## Further Reading
+## See also
 
 [The Circuit Breaker Mechanism in CrateDB]
 

--- a/docs/connect/index.md
+++ b/docs/connect/index.md
@@ -132,7 +132,7 @@ bulk operations and BLOBs, which are not supported by the PostgreSQL
 protocol.
 :::
 
-:::{rubric} Further reading
+:::{rubric} See also
 :::
 
 :::::{grid}

--- a/docs/connect/java.md
+++ b/docs/connect/java.md
@@ -185,7 +185,7 @@ Demonstrates a basic example using both the vanilla PostgreSQL JDBC Driver
 and the CrateDB JDBC Driver.
 :::
 
-## Further reading
+## See also
 
 For testing Java applications against CrateDB, see also documentation
 about {ref}`java-junit` and {ref}`testcontainers`.

--- a/docs/start/modelling/fulltext.md
+++ b/docs/start/modelling/fulltext.md
@@ -145,7 +145,7 @@ WHERE
 This blend lets you query by text relevance, numeric filters, and spatial
 constraints, all in one.
 
-## Further Learning & Resources
+## See also
 
 * {ref}`Full-text Search <fulltext-search>`: In-depth
   walkthrough of full-text search capabilities.

--- a/docs/start/modelling/geospatial.md
+++ b/docs/start/modelling/geospatial.md
@@ -82,7 +82,7 @@ in queries.
 
 See {ref}`Geo Search <crate-reference:sql_dql_geo_search>` for details.
 
-## Further Learning & Resources
+## See also
 
 * Reference manual:
   * {ref}`Geo Search <crate-reference:sql_dql_geo_search>`

--- a/docs/start/modelling/json.md
+++ b/docs/start/modelling/json.md
@@ -168,7 +168,7 @@ table is 1000, more could impact performance.
 Object fields are treated as any other column, therefore **`GROUP BY`**,
 **`HAVING`**, and **window functions** are supported.
 
-## Further Learning & Resources
+## See also
 
 * Reference Manual:
   * {ref}`Objects <crate-reference:data-types-objects>`

--- a/docs/start/modelling/relational.md
+++ b/docs/start/modelling/relational.md
@@ -164,7 +164,7 @@ LEFT JOIN order_counts oc
     ON c.id = oc.customer_id;
 ```
 
-## Further Learning & Resources
+## See also
 
 * Reference Manual:
   * How to {ref}`query with joins <crate-reference:sql_joins>`

--- a/docs/start/modelling/timeseries.md
+++ b/docs/start/modelling/timeseries.md
@@ -156,7 +156,7 @@ All types are supported within the same table or joined together.
 * Supports long‑term retention with performant historic storage.
 * Columnar layout reduces storage footprint and accelerates aggregation queries.
 
-## Further Learning & Resources
+## See also
 
 * **Documentation:** {ref}`Advanced Time Series Analysis <timeseries-analysis>`,
   {ref}`Time Series Long Term Storage <timeseries-longterm>`

--- a/docs/start/modelling/vector.md
+++ b/docs/start/modelling/vector.md
@@ -66,7 +66,7 @@ ORDER BY _score DESC;
 This ranks results by **vector similarity** to the vector supplied by searching
 top 2 nearest neighbours.
 
-## Further Learning & Resources
+## See also
 
 * {ref}`Vector Search <vector-search>`: More details about searching with
   vectors

--- a/docs/start/query/ad-hoc.md
+++ b/docs/start/query/ad-hoc.md
@@ -206,7 +206,7 @@ Learn more about how to use ad-hoc queries effectively.
 | Full-text & filter                    | Combine keyword search with structured queries                                       | {ref}`fts` <br> {ref}`crate-reference:fulltext-indices`      |
 
 
-## Further reading
+## See also
 
 :::::{grid}
 :padding: 0

--- a/docs/start/query/aggregations.md
+++ b/docs/start/query/aggregations.md
@@ -182,7 +182,7 @@ To learn about the full set of integrations, please visit the
 documentation at {ref}`bi` and {ref}`visualization`.
 
 
-## Further reading
+## See also
 
 :::::{grid}
 :padding: 0

--- a/docs/start/query/ai-integration.md
+++ b/docs/start/query/ai-integration.md
@@ -195,7 +195,7 @@ Learn more about how to combine ML features with other major features of CrateDB
 | Time-series support | Perfect for sensor-based training data      | {ref}`timeseries`                      |
 
 
-## Further reading
+## See also
 
 :::::{grid}
 :gutter: 2


### PR DESCRIPTION
## About

- **Ingredients:** Use "See also" when referring to further resources.
- **Reason:** Modernize legacy wording and reduce AI slop.

## Details

**Idea:** Apply a consistent "naming things" across the board like others are doing it.

- https://learn.microsoft.com/en-us/dotnet/framework/data/adonet/#see-also
- https://learn.microsoft.com/en-us/dotnet/framework/configure-apps/#see-also
- https://learn.microsoft.com/en-us/dotnet/framework/tools/signtool-exe#see-also
- https://learn.microsoft.com/en-us/dotnet/framework/whats-new/#see-also

## Preview (samples)

- https://cratedb-guide--428.org.readthedocs.build/admin/circuit-breaker.html#see-also
- https://cratedb-guide--428.org.readthedocs.build/connect/java.html#see-also
- https://cratedb-guide--428.org.readthedocs.build/start/modelling/fulltext.html#see-also
- https://cratedb-guide--428.org.readthedocs.build/start/query/aggregations.html#see-also


## References

- GH-429
