### PR TITLE
Diátaxis: Add "Explanations" section

### DIFF
--- a/docs/explain/index.md
+++ b/docs/explain/index.md
@@ -1,0 +1,22 @@
+(explain)=
+(explanation)=
+(explanations)=
+
+# Explanations
+
+:::{div} sd-text-muted
+Broaden and deepen your knowledge and understanding of CrateDB subject matters.
+:::
+
+The explanatory guides in this section provide more context and background
+about applications and use cases of CrateDB, trying to put things into a
+bigger picture and joining things together to help answer the question _why_?
+
+
+
+:::{note}
+You can expect the more recent documents to be more up-to-date than previous
+ones. If you can discover any flaws, please report them back to us by
+navigating to the tool flyout in the top right corner of each page,
+then using "Suggest improvement" to leave your feedback.
+:::

--- a/docs/handbook/index.md
+++ b/docs/handbook/index.md
@@ -7,7 +7,7 @@ About using CrateDB and CrateDB Cloud in practice.
 :::
 
 
-::::{grid} 2 2 4 4
+::::{grid} 2 2 3 3
 :gutter: 2
 :padding: 0
 
@@ -51,7 +51,7 @@ About using CrateDB and CrateDB Cloud in practice.
 
 How-to guides, tutorials, and explanations.
 
-::::{grid} 2 2 4 4
+::::{grid} 2 2 3 3
 :gutter: 2
 :padding: 0
 
@@ -63,7 +63,7 @@ How-to guides, tutorials, and explanations.
 :class-card: sd-pt-3
 :class-body: sd-fs-1
 :class-title: sd-fs-5
-{material-outlined}`assistant_direction;1.3em`
+{material-outlined}`integration_instructions;1.3em`
 :::
 
 :::{grid-item-card} Tutorials
@@ -75,6 +75,17 @@ How-to guides, tutorials, and explanations.
 :class-body: sd-fs-1
 :class-title: sd-fs-5
 {material-outlined}`school;1.3em`
+:::
+
+:::{grid-item-card} Explanations
+:link: explanations
+:link-type: ref
+:link-alt: Explanations about subject matters concerning CrateDB
+:text-align: center
+:class-card: sd-pt-3
+:class-body: sd-fs-1
+:class-title: sd-fs-5
+{material-outlined}`lightbulb;1.3em`
 :::
 
 :::{grid-item-card} Administration
@@ -247,6 +258,7 @@ programming frameworks, software testing, time series data.
 ../connect/index
 ../howto/index
 ../tutorial/index
+../explain/index
 ../admin/index
 ../performance/index
 ../feature/index


### PR DESCRIPTION
## About

Diátaxis proposes the idea of [explanatory guides](https://diataxis.fr/start-here/#explanation). This patch introduces it by staging a new section to be populated with subsequent patches based on refactoring existing content and adding new one.

## Preview

- https://cratedb-guide--431.org.readthedocs.build/explain/
- https://cratedb-guide--431.org.readthedocs.build/handbook/#learn

## References

- GH-227
- GH-335
