### PR TITLE
Intersphinx: Fix lost `index` link target

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,7 @@
 (index)=
 
+# Welcome to CrateDB
+
 <!--
 NOTE: When adding or removing top-level entries in this toctree, you must also
 update the corresponding hardcoded links in the theme's sidebartoc.html file:
@@ -14,8 +16,6 @@ Look for the "Section A: Guide" section in the {% else %} branch.
 start/index
 handbook/index
 ```
-
-# Welcome to CrateDB
 
 CrateDB is a **distributed SQL database** designed for **real-time analytics,
 search and AI** at scale. Whether you are working with time series data, full-text


### PR DESCRIPTION
## About

Link target labels must be placed above headlines to make them render well into HTML link anchors like `<span id="index"></span>`.

In this case, a recent refactoring displaced the link target label away from its headline. This causes downstream link checkers to fail when trying to resolve the link reference.

```text
projects: line 22 broken
https://cratedb.com/docs/guide/index.html#index - Anchor 'index' not found
```

## References

- https://github.com/crate/crate-docs-theme/actions/runs/18753640989/job/53499716469?pr=640#step:7:703
