### PR TITLE
Integrations/MQTT: Fix `mosquitto_pub` command for Windows

### DIFF
--- a/docs/integrate/mqtt/usage.md
+++ b/docs/integrate/mqtt/usage.md
@@ -52,7 +52,7 @@ docker compose run --rm lorrystream lorry relay "mqtt://mosquitto/testdrive/%23?
 
 Publish a JSON message to an MQTT topic.
 ```shell
-echo '{"temperature": 42.84, "humidity": 83.1}' | docker compose exec --no-tty mosquitto mosquitto_pub -h mosquitto -t testdrive/channel1 -s
+docker compose exec --no-tty mosquitto mosquitto_pub -h mosquitto -t testdrive/channel1 -m '{"temperature":42.84,"humidity":83.1}'
 ```
 
 ## Explore data


### PR DESCRIPTION
## About

After dissolving the problematic `echo ... | mosquitto_pub` command, and omitting white spaces in the value to the `-m` command line option, the usage example will also start working well on Windows. Thanks, @michaelkremmel.

## Preview
https://cratedb-guide--444.org.readthedocs.build/integrate/mqtt/usage.html#submit-data
