### PR TITLE
Remove double "see also" section

### DIFF
--- a/docs/feature/query/index.md
+++ b/docs/feature/query/index.md
@@ -211,23 +211,6 @@ It is also not in the same shape as the other pages in this section.
 :::
 
 
-:::{seealso}
-**Features:**
-[](#relational)
-
-**Domains:**
-[](#metrics-store) •
-[](#analytics) •
-[](#industrial) •
-[](#timeseries) •
-[](#machine-learning)
-
-**Product:**
-[Relational Database] •
-[Indexing, Columnar Storage, and Aggregations]
-:::
-
-
 :::{toctree}
 :maxdepth: 1
 :hidden:


### PR DESCRIPTION
Removed one of the two identical "See also" sections at the bottom.

# Preview
https://cratedb-guide--447.org.readthedocs.build/