### PR TITLE
Welcome: Tune down quick links

### DIFF
--- a/docs/handbook/index.md
+++ b/docs/handbook/index.md
@@ -139,6 +139,14 @@ Use CrateDB with metrics collection agents, brokers, and stores.
 All features of CrateDB at a glance.
 ::::
 
+::::{grid-item-card}
+:link: integrate
+:link-type: ref
+{material-outlined}`integration_instructions;2em` &nbsp; **Integrate**
++++
+Integrate with third-party applications and frameworks.
+::::
+
 :::::
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,60 +29,13 @@ more about high-level features and use cases.
 This documentation is about helping you get started, explore in practice, and
 operate in details.
 
-::::{grid} 2 2 2 3
-:gutter: 3
-
-:::{grid-item-card}
-:link: getting-started
-:link-type: ref
-:class-header: sd-text-center sd-fs-5 sd-align-minor-center sd-font-weight-bold sd-text-capitalize
-:class-body: sd-text-center sd-fs-5
-:class-footer: text-smaller
-Getting started
-^^^
-{material-outlined}`not_started;3.5em`
-+++
-Learn how to interact with the database for the first time.
-:::
-
-:::{grid-item-card}
-:link: connect
-:link-type: ref
-:link-alt: CrateDB: Client Drivers and Libraries
-:class-header: sd-text-center sd-fs-5 sd-align-minor-center sd-font-weight-bold sd-text-capitalize
-:class-body: sd-text-center sd-fs-5
-:class-footer: text-smaller
-Connect
-^^^
-{material-outlined}`link;3.5em`
-+++
-Database drivers, libraries, adapters, and connectors.
-:::
-
-:::{grid-item-card}
-:link: integrate
-:link-type: ref
-:link-alt: Integrations
-:class-header: sd-text-center sd-fs-5 sd-align-minor-center sd-font-weight-bold sd-text-capitalize
-:class-body: sd-text-center sd-fs-5
-:class-footer: text-smaller
-Integrate
-^^^
-{material-outlined}`integration_instructions;3.5em`
-+++
-Integrate with third-party applications and frameworks.
-:::
-
-::::
-
-
 :::{rubric} Start
 :::
 
 ::::{grid} 2
 :gutter: 3
 
-:::{grid-item-card} {material-outlined}`not_started;1.7em` CrateDB Cloud
+:::{grid-item-card} {material-outlined}`arrow_circle_right;1.7em` CrateDB Cloud
 :link: https://console.cratedb.cloud/
 :link-type: url
 :link-alt: Getting started with CrateDB Cloud
@@ -110,6 +63,32 @@ for on-premises operations and development purposes.
 
 ::::
 
+:::{rubric} Quick links
+:::
+
+:::::{grid} 2 2 2 3
+:gutter: 2
+:padding: 0
+
+::::{grid-item-card} {material-outlined}`not_started;2em` &nbsp; Getting started
+:link: getting-started
+:link-type: ref
+Learn how to interact with the database for the first time.
+::::
+
+::::{grid-item-card} {material-outlined}`link;2em` &nbsp; Connect
+:link: connect
+:link-type: ref
+Database drivers, libraries, adapters, and connectors.
+::::
+
+::::{grid-item-card} {material-outlined}`auto_stories;2em` &nbsp; Handbook
+:link: handbook
+:link-type: ref
+Use CrateDB and CrateDB Cloud in practice.
+::::
+
+:::::
 
 :::{rubric} Testimonials
 :::


### PR DESCRIPTION
## About
Just a bit of copy editing about layout, also tuning down card representations a bit more, for saving screen space on index pages, and improving user guidance.

## Preview
- Before: https://cratedb.com/docs/guide/
- After: https://cratedb-guide--453.org.readthedocs.build/

## Review
The patch does not include any complexities or many words to review, so the review is merely asking about your opinion if you think the page is reasonably appealing. Please share any suggestions to improve.

## References
- GH-227
- GH-446

/cc @karynzv, @hammerhead, @surister, @zolbatar, @grbade