### PR TITLE
Sweep: Fix Docker invocation on Windows/PowerShell

### DIFF
--- a/docs/admin/clustering/logical-replication-setup.md
+++ b/docs/admin/clustering/logical-replication-setup.md
@@ -33,7 +33,7 @@ docker run \
   --publish 5433:5432 \
   --env CRATE_HEAP_SIZE=1g \
   crate:latest \
-  -Cdiscovery.type=single-node
+  '-Cdiscovery.type=single-node'
 ```
 ```shell
 docker run \
@@ -43,7 +43,7 @@ docker run \
   --publish 5434:5432 \
   --env CRATE_HEAP_SIZE=1g \
   crate:latest \
-  -Cdiscovery.type=single-node
+  '-Cdiscovery.type=single-node'
 ```
 
 We apply an offset to the ports of each cluster, so they don't overlap. The

--- a/docs/admin/troubleshooting/jcmd/docker.md
+++ b/docs/admin/troubleshooting/jcmd/docker.md
@@ -65,13 +65,13 @@ Let's start by starting a `cratedb` container.
 docker run --rm -it --name=cratedb \
     --publish=4200:4200 --publish=5432:5432 \
     --env=CRATE_HEAP_SIZE=1g crate/crate:nightly \
-    -Cdiscovery.type=single-node
+    '-Cdiscovery.type=single-node'
 ```
 
 ```console
 docker exec -it --user=crate cratedb /bin/bash
 $ /crate/jdk/bin/jcmd -l
-1 io.crate.bootstrap.CrateDB -Cpath.home=/crate -Cdiscovery.type=single-node
+1 io.crate.bootstrap.CrateDB -Cpath.home=/crate '-Cdiscovery.type=single-node'
 301 jdk.jcmd/sun.tools.jcmd.JCmd -l
 ```
 

--- a/docs/feature/search/fts/analyzer.md
+++ b/docs/feature/search/fts/analyzer.md
@@ -172,7 +172,7 @@ s(900516492,3,'Bill',n,1,0).
 docker run --rm -it --name=cratedb --publish=4200:4200 --env=CRATE_HEAP_SIZE=1g \
   --volume="$PWD/synonyms-solr.txt:/crate/config/synonyms-solr.txt" \
   --volume="$PWD/synonyms-wordnet.txt:/crate/config/synonyms-wordnet.txt" \
-  crate -Cdiscovery.type=single-node
+  crate '-Cdiscovery.type=single-node'
 ```
 
 This example uses the `synonyms-solr.txt` in Solr format.

--- a/docs/integrate/airflow/import-stock-market-data.md
+++ b/docs/integrate/airflow/import-stock-market-data.md
@@ -21,7 +21,7 @@ Set up on macOS. Ensure Homebrew is installed and Docker Desktop is running.
 
 First, run CrateDB with Docker. With Docker Desktop running, copy the command from the CrateDB installation page and run it:
 ```bash
-docker run --publish=4200:4200 --publish=5432:5432 --env CRATE_HEAP_SIZE=1g crate:latest -Cdiscovery.type=single-node
+docker run --publish=4200:4200 --publish=5432:5432 --env CRATE_HEAP_SIZE=1g crate:latest '-Cdiscovery.type=single-node'
 ```
 
 With CrateDB running, you can now access the CrateDB Admin UI by going to

--- a/docs/integrate/debezium/tutorial.md
+++ b/docs/integrate/debezium/tutorial.md
@@ -89,7 +89,7 @@ We will need a CrateDB instance, for the purpose of this example we can spin one
 
 ```bash
 sudo apt install docker.io
-sudo docker run --publish 4200:4200 --publish 5432:5432 --env CRATE_HEAP_SIZE=1g crate:latest -Cdiscovery.type=single-node
+sudo docker run --publish 4200:4200 --publish 5432:5432 --env CRATE_HEAP_SIZE=1g crate:latest '-Cdiscovery.type=single-node'
 ```
 
 Now we need to run a couple of SQL commands on this instance, an easy way to do this is using the Admin UI that can be accessed navigating with a web browser to port 4200 on the server where CrateDB is running, for instance `http://localhost:4200` and then open the console (second icon from the top on the left-hand side navigation bar).

--- a/docs/integrate/marquez/usage.md
+++ b/docs/integrate/marquez/usage.md
@@ -65,7 +65,7 @@ astro dev start
 And we will start a single-node local CrateDB instance using port 5436 for the PostgreSQL wire protocol interface:
 
 ```bash
-sudo docker run -d --name cratedb --publish=4200:4200 --publish=5436:5432 --env CRATE_HEAP_SIZE=1g crate/crate:5.9.5 -Cdiscovery.type=single-node
+sudo docker run -d --name cratedb --publish=4200:4200 --publish=5436:5432 --env CRATE_HEAP_SIZE=1g crate/crate:5.9.5 '-Cdiscovery.type=single-node'
 ```
 
 (NB this will return immediately once the image is downloaded but CrateDB may take a few seconds to start)

--- a/docs/integrate/risingwave/apache-iceberg.md
+++ b/docs/integrate/risingwave/apache-iceberg.md
@@ -32,7 +32,7 @@ podman run -d --name risingwave -it -p 4566:4566 -p 5691:5691 docker.io/risingwa
 And finally, an instance of CrateDB:
 
 ```bash
-podman run -d --name cratedb --publish=4200:4200 --publish=5432:5432 --env CRATE_HEAP_SIZE=1g docker.io/crate/crate:5.10.7 -Cdiscovery.type=single-node
+podman run -d --name cratedb --publish=4200:4200 --publish=5432:5432 --env CRATE_HEAP_SIZE=1g docker.io/crate/crate:5.10.7 '-Cdiscovery.type=single-node'
 ```
 
 We will need three terminals for this demonstration.

--- a/docs/integrate/rsyslog/usage.md
+++ b/docs/integrate/rsyslog/usage.md
@@ -27,7 +27,7 @@ setup.
 First, start CrateDB. For production, use a dedicated cluster. For this demo, run a single‑node container:
 
 ```bash
-sudo docker run -d --name cratedb -p 4200:4200 -p 5432:5432 -e CRATE_HEAP_SIZE=1g crate:latest -Cdiscovery.type=single-node
+sudo docker run -d --name cratedb -p 4200:4200 -p 5432:5432 -e CRATE_HEAP_SIZE=1g crate:latest '-Cdiscovery.type=single-node'
 ```
 
 Next, create a table for logs. Open `http://localhost:4200/#!/console` or invoke `crash` and run:

--- a/docs/integrate/superset/sandbox.md
+++ b/docs/integrate/superset/sandbox.md
@@ -13,7 +13,7 @@ You will need Bash, Docker, Git, and Python to be installed on your workstation.
 
 Start CrateDB using Docker.
 ```shell
-docker run --rm --publish=4200:4200 --publish=5432:5432 --name=cratedb --env CRATE_HEAP_SIZE=1g crate:latest -Cdiscovery.type=single-node
+docker run --rm --publish=4200:4200 --publish=5432:5432 --name=cratedb --env CRATE_HEAP_SIZE=1g crate:latest '-Cdiscovery.type=single-node'
 ```
 
 Create an example table and insert a single record.

--- a/docs/integrate/superset/usage.md
+++ b/docs/integrate/superset/usage.md
@@ -44,7 +44,7 @@ docker run --interactive --rm --pull=always \
   --publish=4200:4200 --publish=5432:5432 \
   --name=cratedb \
   --env CRATE_HEAP_SIZE=1g \
-  crate:latest -Cdiscovery.type=single-node
+  crate:latest '-Cdiscovery.type=single-node'
 ```
 
 Run Superset server.


### PR DESCRIPTION
## About
@matriv discovered that when using Docker on Windows/PowerShell, users must quote `-C` parameters.

> The workaround for Docker is to include each setting in single
> quotes, like `'-Cdiscovery.type=single-node'`.

```shell
docker run --rm --publish=4200:4200 --publish=5432:5432 docker.io/crate '-Cdiscovery.type=single-node'
```

## References
- GH-325
- https://github.com/crate/cratedb-guide/issues/390#issuecomment-3410751473
- https://github.com/crate/crate/pull/18631

/cc @karynzv, @surister, @seut, @michaelkremmel, @grbade 