### PR TITLE
Install/Windows: Add `tar` option to extract Zip archive (available with Win10). Remove `unzip`.

### DIFF
--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -26,11 +26,6 @@ us][contact us] so we can work with you on a solution.
    tar -xf .\crate-*.zip
    ```
 
-   Using unzip:
-   ```doscon
-   unzip -o crate-*.zip
-   ```
-
 3. On the terminal, change into the extracted `crate` directory:
 
    ```doscon


### PR DESCRIPTION
## About
Windows 10 includes the `tar` program. `unzip` doesn't work, see conversation below.

## Preview
- https://cratedb-guide--480.org.readthedocs.build/install/windows.html

## References
- GH-397

