### PR TITLE
Enable parallel builds by using newest theme and docs builder

### DIFF
--- a/docs/build.json
+++ b/docs/build.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
   "label": "docs build",
-  "message": "2.1.2"
+  "message": "2.1.4"
 }

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-crate-docs-theme>=0.41.0.dev2
+crate-docs-theme>=0.42.0
 
 # Comment the first line and uncomment and adjust path in the following line
 # to use a local version of crate-docs-theme:


### PR DESCRIPTION
## About
The most recent theme allows parallel builds, so let's use them also here.

## References
- https://github.com/crate/crate-docs/pull/119

/cc @surister 