### PR TITLE
Build: Use `uv` package manager on Read the Docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,22 +7,16 @@ build:
   jobs:
     # Install `uv`.
     # https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-uv
-    create_environment:
+    pre_create_environment:
       - asdf plugin add uv
       - asdf install uv latest
       - asdf global uv latest
-      - uv venv
-
-    # Install dependencies using `uv`.
+    create_environment:
+      - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
     install:
-      - uv pip install -r docs/requirements.txt
+      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv pip install -r docs/requirements.txt
 
     # Invoke the build using `uv`.
     build:
       html:
-        - uv run sphinx-build -T -b html docs $READTHEDOCS_OUTPUT/html
-
-sphinx:
-  builder: html
-  configuration: docs/conf.py
-  fail_on_warning: true
+        - uv run sphinx-build -W -T -b html docs $READTHEDOCS_OUTPUT/html


### PR DESCRIPTION
## About
Use `uv` also on RTD.

## Preview
https://cratedb-guide--514.org.readthedocs.build/