### PR TITLE
Fix `MAX_BY`/`MIN_BY` bold formatting

### DIFF
--- a/docs/start/modelling/timeseries.md
+++ b/docs/start/modelling/timeseries.md
@@ -70,7 +70,7 @@ CrateDB offers built‑in SQL functions tailor‑made for time‑series analyses
 * **`DATE_BIN(interval, timestamp, origin)`** for bucketed aggregations
   (down‑sampling).
 * **Window functions** like `LAG()` and `LEAD()` to detect trends or gaps.
-* **`MAX_BY(returnField, SearchField)` / `MIN_BY(returnField, SearchField)` ** returns the value from one column matching the min/max value of
+* **`MAX_BY(returnField, SearchField)` / `MIN_BY(returnField, SearchField)`** returns the value from one column matching the min/max value of
   another column in a group.
 
 **Example**: compute hourly average battery levels and join with metadata:


### PR DESCRIPTION
## About

Formatting around `MAX_BY`/`MIN_BY` was previously not applied correctly.

Before:
<img width="870" height="194" alt="Screenshot 2026-01-12 at 10 05 31" src="https://github.com/user-attachments/assets/aea83079-f25b-4dc2-9256-6bb5f9c3297e" />

After:
<img width="833" height="184" alt="Screenshot 2026-01-12 at 10 05 41" src="https://github.com/user-attachments/assets/747cc156-ed49-4714-a400-8191f82328b9" />

## Preview

https://cratedb-guide--520.org.readthedocs.build/start/modelling/timeseries.html
