### PR TITLE
Remove "All drivers" from index

### DIFF
--- a/docs/connect/drivers.md
+++ b/docs/connect/drivers.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 (connect-drivers)=
 # All drivers and client libraries
 

--- a/docs/connect/index.md
+++ b/docs/connect/index.md
@@ -302,7 +302,6 @@ scala/index
 odbc/index
 visualbasic/index
 natural
-All drivers <drivers>
 ```
 
 


### PR DESCRIPTION
## About
This removed the redirect that happens when you click "Database Drivers" and get redirected into the Handbook. That's very confusing in the TOC. Also the page is outdated with the addition of other drivers in the handbook now.
When is removed from the TOC here, it appears as the content for "Database Drivers" - for now. We can update the content later. For now I would just like to remove the strange redirect.

Related to https://github.com/crate/tech-content/issues/124

## Preview
https://cratedb-guide--521.org.readthedocs.build/

Not much to "see", except that the "All Drivers" TOC entry is gone.

