### PR TITLE
RTD: Turn off output buffering for better output on the build console

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,4 +19,4 @@ build:
     # Invoke the build using `uv`.
     build:
       html:
-        - PYTHONUNBUFFERED=true uv run sphinx-build -W -T -b html docs $READTHEDOCS_OUTPUT/html
+        - ${READTHEDOCS_VIRTUALENV_PATH}/bin/sphinx-build -W -T -b html docs $READTHEDOCS_OUTPUT/html


### PR DESCRIPTION
## About
Just an attempt to improve realtime build output after switching to `uv run`.

## Preview
Build: https://app.readthedocs.org/projects/cratedb-guide/builds/31314323/
View: https://cratedb-guide--542.org.readthedocs.build/
