### PR TITLE
Integrations: Move reference to "categories" page to the top

### DIFF
--- a/docs/integrate/index.md
+++ b/docs/integrate/index.md
@@ -9,17 +9,17 @@ This documentation section lists applications, frameworks, and libraries,
 which can be used together with CrateDB, and outlines how to use them
 optimally.
 
-:::{toctree}
-:maxdepth: 1
-:glob:
-
-*/index
-:::
-
-You can also explore integrations by other angles.
+Explore integrations by category.
 :::{toctree}
 :maxdepth: 1
 category/overview
+:::
+
+Explore integrations sorted alphanumerically.
+:::{toctree}
+:maxdepth: 1
+:glob:
+*/index
 :::
 
 


### PR DESCRIPTION
## About
> Perhaps move the "By category" up to the top, perhaps even enumerate them directly? And then the long index afterwards?

## Preview
- https://cratedb-guide--544.org.readthedocs.build/integrate/

## References
- https://github.com/crate/cratedb-guide/pull/543#pullrequestreview-3772579461