### PR TITLE
Warehouse Migrations: Hide content until section will be re-populated

### DIFF
--- a/docs/integrate/category/migrate/index.md
+++ b/docs/integrate/category/migrate/index.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 (migrations)=
 # Migrations
 

--- a/docs/integrate/category/migrate/rockset/index.md
+++ b/docs/integrate/category/migrate/rockset/index.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 (rockset)=
 # Welcome Rockset Developers
 

--- a/docs/integrate/category/overview.md
+++ b/docs/integrate/category/overview.md
@@ -64,6 +64,7 @@ Django, Gradio, Plotly, PyViz, QueryZen, Streamlit.
 :link: migrations
 :link-type: ref
 :link-alt: Migrate workloads to CrateDB
+:class-item: visually-hidden
 Guidelines, tools, and ETL recipes, to support migrating data
 warehouse workloads to CrateDB.
 +++


### PR DESCRIPTION
## About
> Optional: remove Rockset migration entirely? Likely no one is left to migrate.

Yes, it's a bit lonely. Let's rework and expand it later, so hide it for now?

## Preview
- https://cratedb-guide--545.org.readthedocs.build/integrate/category/overview.html

## References
- https://github.com/crate/cratedb-guide/pull/543#pullrequestreview-3772598725