### PR TITLE
Link management: Restored original `04_lucene_vector_search_sokolov.pdf`

### DIFF
--- a/docs/feature/search/vector/index.md
+++ b/docs/feature/search/vector/index.md
@@ -291,7 +291,7 @@ features of Lucene 9, and about the journey of implementing HNSW from
 
 
 [Lucene Is All You Need]: https://arxiv.org/pdf/2308.14963
-[making of Lucene vector search]: https://web.archive.org/web/20250115175831/https://www.apachecon.com/acna2022/slides/04_lucene_vector_search_sokolov.pdf
+[making of Lucene vector search]: https://www.apachecon.com/acna2022/slides/04_lucene_vector_search_sokolov.pdf
 [Time series data in manufacturing]: https://github.com/crate/cratedb-datasets/raw/main/machine-learning/fulltext/White%20paper%20-%20Time-series%20data%20in%20manufacturing.pdf
 [Uwe Schindler - What's coming next with Apache Lucene?]: https://youtu.be/EHJjSYWjIF0?t=330s&feature=shared
 [Vector search in Elasticsearch]: https://www.elastic.co/search-labs/blog/articles/vector-search-elasticsearch-rationale


### PR DESCRIPTION
Just maintenance.